### PR TITLE
docs: clarify Claude and Gemini host integration boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,13 @@ cam session status
 1. 继续做小步 stack closure，而不是重新摊大 remediation
 2. 优先把 help / docs / smoke contract 固定成同一套公开语义
 3. 在不扩张宿主边界的前提下，继续维持 Codex-first、manual-only 非 Codex host 的产品表述
+4. 将 issue5 剩余 closeout seams 继续拆成小 PR：`cam init` 幂等/`--force`、`cam session status/load` 只读化、Vitest `.worktrees/**` 边界、docs/help parity
+5. 保持发布面验证串行执行：`dist-cli-smoke` 与 `tarball-install-smoke` 不并行跑，避免 `prepack -> rimraf dist` 造成假阴性
 
 ## 变更记录
 
+- 2026-04-10: issue5 PR14 收口了三类 runtime contract seam：`mcp` 命令的空 `--cwd` 现在 fail-closed；`workflowContract` 的 resolved launcher 与显式 `launcherOverride` 保持一致；delete-only 的 forget follow-up 文案不再硬编码裸 `cam recall timeline`。
+- 2026-04-10: `test/recovery-records.test.ts` 已对齐当前 continuity 语义：`scope=both` continuity recovery marker 可以被后续 single-scope save/refresh 复用，并继续由 `session-command` 行为测试锁定。
 - 2026-04-10: 新增根级 `AGENTS.md`，补齐仓库级功能说明、命令面、关键 JSON 契约与项目规划。
 - 2026-04-10: 明确 `cam integrations install --help` 与四语 README 命令表的公开边界：install 编排 stack，但不更新 `AGENTS.md`。
 - 2026-04-10: 新增 Claude Code / Gemini CLI 宿主接入边界文档，并同步收紧宿主策略文档与 README 入口，明确非 Codex 宿主当前仍是 manual-only / snippet-first。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,11 @@ cam session status
 当前优先事项：
 
 1. 继续保持 issue5 stack 的 reviewer contract、help surface、release-facing smoke 一致
-2. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
-3. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
-4. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
-5. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
+2. 收紧 issue-tracker durable memory replacement key，避免不同 host 的 tracker URL 因相同 repo/path 或 ticket id 被误判为同一条 memory
+3. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
+4. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
+5. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
+6. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
 
 下一阶段建议：
 
@@ -106,6 +107,7 @@ cam session status
 
 ## 变更记录
 
+- 2026-04-11: issue5 tail closeout 新增 cross-host issue-tracker 回归保护：`directive-utils` 现在用完整的 non-generic hostname 片段构造 issue-tracker resource key，避免不同 host 但相同 repo/path 或 ticket id 的 URL 互相覆盖；同时补强 `vitest.config.ts` 的默认 exclude contract 测试，并把 `integrations apply --cwd` 的 invalid-path fail-closed 行为纳入 source / dist / tarball 回归覆盖。
 - 2026-04-10: issue5 PR14 收口了三类 runtime contract seam：`mcp` 命令的空 `--cwd` 现在 fail-closed；`workflowContract` 的 resolved launcher 与显式 `launcherOverride` 保持一致；delete-only 的 forget follow-up 文案不再硬编码裸 `cam recall timeline`。
 - 2026-04-10: `test/recovery-records.test.ts` 已对齐当前 continuity 语义：`scope=both` continuity recovery marker 可以被后续 single-scope save/refresh 复用，并继续由 `session-command` 行为测试锁定。
 - 2026-04-10: 新增根级 `AGENTS.md`，补齐仓库级功能说明、命令面、关键 JSON 契约与项目规划。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,9 +91,10 @@ cam session status
 当前优先事项：
 
 1. 继续保持 issue5 stack 的 reviewer contract、help surface、release-facing smoke 一致
-2. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
-3. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
-4. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
+2. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
+3. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
+4. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
+5. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
 
 下一阶段建议：
 
@@ -105,3 +106,4 @@ cam session status
 
 - 2026-04-10: 新增根级 `AGENTS.md`，补齐仓库级功能说明、命令面、关键 JSON 契约与项目规划。
 - 2026-04-10: 明确 `cam integrations install --help` 与四语 README 命令表的公开边界：install 编排 stack，但不更新 `AGENTS.md`。
+- 2026-04-10: 新增 Claude Code / Gemini CLI 宿主接入边界文档，并同步收紧宿主策略文档与 README 入口，明确非 Codex 宿主当前仍是 manual-only / snippet-first。

--- a/README.en.md
+++ b/README.en.md
@@ -323,6 +323,7 @@ See the architecture docs for the full boundary breakdown.
 ### Core design docs
 
 - [Claude reference contract (中文)](docs/claude-reference.md) | [English](docs/claude-reference.en.md)
+- [Claude Code / Gemini CLI host integration boundaries (中文)](docs/host-integration-claude-gemini.md)
 - [Architecture (中文)](docs/architecture.md) | [English](docs/architecture.en.md)
 - [Integration strategy (中文)](docs/integration-strategy.md)
 - [Host surfaces (中文)](docs/host-surfaces.md)

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Session continuity：
 ### 核心设计文档
 
 - [Claude Code 参考契约（中文）](docs/claude-reference.md) | [English](docs/claude-reference.en.md)
+- [Claude Code / Gemini CLI 宿主接入边界（中文）](docs/host-integration-claude-gemini.md)
 - [架构设计（中文）](docs/architecture.md) | [English](docs/architecture.en.md)
 - [集成演进策略（中文）](docs/integration-strategy.md)
 - [宿主能力面（中文）](docs/host-surfaces.md)

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -14,6 +14,7 @@
 3. [Architecture](./architecture.en.md)
 4. [Integration strategy](./integration-strategy.md) (Chinese)
 5. [Native migration strategy](./native-migration.en.md)
+6. [Claude Code / Gemini CLI host integration boundaries](./host-integration-claude-gemini.md) (Chinese)
 
 ### Maintainers
 
@@ -23,6 +24,7 @@
 4. [Session continuity design](./session-continuity.md)
 5. [Release checklist](./release-checklist.md)
 6. [ClaudeCode patch audit](./claudecode-patch-audit.md)
+7. [Claude Code / Gemini CLI host integration boundaries](./host-integration-claude-gemini.md) (Chinese)
 
 ### Reviewers and follow-up agents
 
@@ -32,12 +34,14 @@
 4. [Host surfaces](./host-surfaces.md) (Chinese)
 5. [Native migration strategy](./native-migration.en.md)
 6. [Session continuity design](./session-continuity.md)
+7. [Claude Code / Gemini CLI host integration boundaries](./host-integration-claude-gemini.md) (Chinese)
 
 ## Core design docs
 
 | Document | Purpose | Language |
 | :-- | :-- | :-- |
 | [Claude reference contract](./claude-reference.en.md) | defines which public Claude Code memory behaviors this project intentionally mirrors, and where it now intentionally diverges | English / [中文](./claude-reference.md) |
+| [Claude Code / Gemini CLI host integration boundaries](./host-integration-claude-gemini.md) | explains the difference between publicly documented Claude/Gemini host surfaces and the manual-only integration boundary this repository currently supports | 中文 |
 | [Architecture](./architecture.en.md) | explains the current Codex-first Hybrid architecture: wrapper path today, broader integration surfaces tomorrow | English / [中文](./architecture.md) |
 | [Integration strategy](./integration-strategy.md) | explains how the current repository expands from a Codex companion into a Codex-first Hybrid memory system | 中文 |
 | [Host surfaces](./host-surfaces.md) | records host capability boundaries and future integration posture across Codex and adjacent ecosystems | 中文 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 2. [Claude Code 参考契约](./claude-reference.md)
 3. [架构设计](./architecture.md)
 4. [集成演进策略](./integration-strategy.md)
+5. [Claude Code / Gemini CLI 宿主接入边界](./host-integration-claude-gemini.md)
 
 ### 维护者
 
@@ -22,6 +23,7 @@
 4. [Session continuity 设计](./session-continuity.md)
 5. [Native migration 策略](./native-migration.md)
 6. [Release checklist](./release-checklist.md)
+7. [Claude Code / Gemini CLI 宿主接入边界](./host-integration-claude-gemini.md)
 
 ### Reviewer / 外部审查工具
 
@@ -30,12 +32,14 @@
 3. [集成演进策略](./integration-strategy.md)
 4. [宿主能力面](./host-surfaces.md)
 5. [Session continuity 设计](./session-continuity.md)
+6. [Claude Code / Gemini CLI 宿主接入边界](./host-integration-claude-gemini.md)
 
 ## 核心设计文档
 
 | 文档 | 作用 | 语言 |
 | :-- | :-- | :-- |
 | [Claude Code 参考契约](./claude-reference.md) | 说明本项目主动对齐的 Claude Code memory 契约边界 | 中文 / [English](./claude-reference.en.md) |
+| [Claude Code / Gemini CLI 宿主接入边界](./host-integration-claude-gemini.md) | 收口 Claude / Gemini 当前公开宿主面与本仓真实支持边界之间的关系 | 中文 |
 | [架构设计](./architecture.md) | 解释当前主实现：startup injection、sync、continuity 与 Markdown store | 中文 / [English](./architecture.en.md) |
 | [集成演进策略](./integration-strategy.md) | 解释当前仓库如何从 Codex companion 演进为 Codex-first Hybrid memory system | 中文 |
 | [宿主能力面](./host-surfaces.md) | 固化当前仓库对 Codex 及其他宿主的能力判断与边界 | 中文 |

--- a/docs/host-integration-claude-gemini.md
+++ b/docs/host-integration-claude-gemini.md
@@ -1,0 +1,190 @@
+# Claude Code / Gemini CLI 宿主接入边界
+
+> 本文回答两个问题：  
+> 1. Claude Code 与 Gemini CLI 当前公开了哪些值得对齐的宿主能力面。  
+> 2. 在这些公开能力已经存在的前提下，`codex-auto-memory` 现在真正应该支持到哪一层。
+
+## 一页结论
+
+当前最稳的结论应固定为：
+
+- `codex-auto-memory` 仍然是 **Codex-first Hybrid memory system**
+- Claude Code 与 Gemini CLI 都是 **重要参考宿主**
+- 当前仓库对 Claude / Gemini 的真实接入面仍是：
+  - `cam mcp print-config --host <claude|gemini>`
+  - `cam mcp doctor --host <claude|gemini>`
+  - manual-only / snippet-first 的宿主接线指导
+- 当前仓库 **不** 应在这一轮新增：
+  - `claude` / `gemini` 的自动写配置 install/apply
+  - Claude / Gemini host-native hooks/skills/extensions 的自动安装
+  - 多宿主统一 runtime 抽象
+
+## 证据分层
+
+### A. 官方公开资料
+
+应优先信任以下公开面：
+
+- Claude Code 官方文档：
+  - memory
+  - settings
+  - hooks
+  - sub-agents
+  - MCP
+- Claude Code 官方仓库公开资料：
+  - `anthropics/claude-code`
+  - plugins 公开说明
+- Gemini CLI 官方仓库公开资料：
+  - `google-gemini/gemini-cli`
+  - `settings.json` / project-scoped `.gemini/settings.json`
+  - `GEMINI.md`
+  - memory / `save_memory`
+  - hooks
+  - skills
+  - extensions
+  - MCP
+
+### B. 当前仓库事实
+
+当前仓库代码与测试已经明确表达：
+
+- `cam mcp install` 只有 `codex` 可写
+- `claude` / `gemini` / `generic` 继续保持 manual-only / snippet-first
+- `cam mcp print-config --host <claude|gemini>` 可以给出宿主接线片段
+- `cam mcp doctor --host <claude|gemini>` 只能检查 snippet/config truth，不冒充 Codex 级 operational readiness
+
+### C. 非官方研究资料
+
+例如：
+
+- `Boulea7/ClaudeCode-Source-DeepDive`
+
+这类资料可以帮助理解内部结构与未来可能的适配点，但不能单独升级为本仓的公开产品承诺。
+
+## Claude Code：当前应如何看待
+
+Claude Code 当前公开的能力面足够强，至少已经把以下内容放进了公开宿主表面：
+
+- memory
+- settings
+- hooks
+- sub-agents
+- MCP
+- plugins / commands / agents / skills / hooks / MCP 组合扩展
+
+对当前仓库的含义：
+
+- Claude 是 **产品契约参考宿主**
+- Claude memory contract 继续是本仓 memory semantics 的高价值对齐对象
+- Claude hooks / sub-agents / plugins 继续是未来 host adapter 设计的重要参照
+- 但当前仓库不应把这些公开能力误写成“本仓已经支持 Claude host-native integration”
+
+当前真实可做的 Claude 接入：
+
+- 用 `cam mcp print-config --host claude` 生成 `.mcp.json` 片段
+- 由用户手动粘贴到 Claude host config
+- 用 `cam mcp doctor --host claude --cwd <path>` 检查当前 snippet/config 是否存在且 project-pinned
+
+当前不应做的 Claude 接入：
+
+- `cam mcp install --host claude`
+- `cam integrations install/apply --host claude`
+- 自动写 Claude hooks / plugins / skills / subagent 资产
+
+## Gemini CLI：当前应如何看待
+
+Gemini CLI 的公开宿主面已经明显超过“只有一个 MCP config file”的水平。当前公开能力至少包括：
+
+- `~/.gemini/settings.json` 与 `.gemini/settings.json`
+- `GEMINI.md` 分层上下文
+- memory / `save_memory`
+- hooks
+- skills
+- extensions
+- MCP
+
+这意味着 Gemini 不是“只够拿来对照 MCP 片段”的宿主，而是：
+
+- 一个公开 surface 相当丰富的参考宿主
+- 一个未来可能值得单独做 adapter 的宿主
+- 但在当前仓库里，仍然不应直接升级成可写主宿主
+
+当前真实可做的 Gemini 接入：
+
+- 用 `cam mcp print-config --host gemini` 生成 `.gemini/settings.json` 里的 `mcpServers` 片段
+- 保持 `trust=false` 这类 host-controlled 安全边界
+- 用 `cam mcp doctor --host gemini --cwd <path>` 检查 project-scoped 或 user-scoped wiring truth
+- 在文档里明确：Gemini 自己还有 `GEMINI.md`、hooks、skills、extensions、memory 这些 host-native surface，但本仓当前不接管它们的自动安装
+
+当前不应做的 Gemini 接入：
+
+- `cam mcp install --host gemini`
+- `cam integrations install/apply --host gemini`
+- 自动写 `.gemini/settings.json`
+- 自动安装 Gemini hooks / skills / extensions
+
+## 当前仓库的正式边界
+
+当前仓库对外应保持以下一致表述：
+
+- Codex 是唯一的 mutable host
+- Claude / Gemini / generic 的当前策略都是 manual-only / snippet-first
+- `mcp print-config` 与 `mcp doctor` 是非 Codex 宿主当前真实支持的边界
+- 这条边界是有意收口，不是“忘了做”
+
+更具体地说：
+
+- Codex：
+  - 可写 install / apply / integrations stack
+  - 可管理 repo-level `AGENTS.md` guidance
+  - 可汇总 Codex-only route truth
+- Claude：
+  - 当前只提供 manual-only MCP wiring guidance
+  - 当前不提供自动写 config / hooks / plugins / skills
+- Gemini：
+  - 当前只提供 manual-only MCP wiring guidance
+  - 当前不提供自动写 config / hooks / skills / extensions
+
+## 这一轮可以直接做什么
+
+可以直接做：
+
+- 收紧文档与 README 里的宿主边界表述
+- 明确区分：
+  - 官方公开宿主能力
+  - 本仓当前真正支持的接入面
+  - deferred 的 host-native integration 面
+- 保持 `mcp print-config` / `mcp doctor` 对 Claude/Gemini 的 manual-only 叙事稳定
+
+应 deferred：
+
+- Claude/Gemini 可写 install/apply
+- host-native hooks / skills / extensions 自动安装
+- 多宿主统一 memory runtime 抽象
+
+需要额外验证后再动：
+
+- 是否值得单独为 Gemini 再开一条更细的 manual-host contract PR
+- Claude plugins / marketplace / skills 的哪些表面属于“稳定公开能力”，哪些仍应只作为参考面引用
+
+## 推荐的后续动作
+
+如果未来要继续推进 Claude / Gemini 适配，建议按以下顺序：
+
+1. 先把文档、README、help、tests 对齐到当前真实边界
+2. 再单独评估 `manual-only host snippet/doctor parity` 是否需要代码级 closure
+3. 如果未来真的要做 host-native adapter，再在独立 PR 中分别处理 Claude 与 Gemini，而不是一次性摊平成多宿主统一层
+
+## 参考来源
+
+- Claude Code 官方文档：
+  - <https://code.claude.com/docs/en/memory>
+  - <https://code.claude.com/docs/en/settings>
+  - <https://code.claude.com/docs/en/hooks>
+  - <https://code.claude.com/docs/en/sub-agents>
+- Claude Code 官方仓库：
+  - <https://github.com/anthropics/claude-code>
+- Gemini CLI 官方仓库：
+  - <https://github.com/google-gemini/gemini-cli>
+- 非官方研究参考：
+  - <https://github.com/Boulea7/ClaudeCode-Source-DeepDive>

--- a/docs/host-surfaces.md
+++ b/docs/host-surfaces.md
@@ -42,6 +42,7 @@
 价值：
 
 - 提供最完整的官方 auto memory、hooks、plugins、skills、subagents 参考契约
+- 官方公开 surface 足够丰富，适合作为本仓 memory / host boundary 的高价值对照对象
 
 在当前仓库里的角色：
 
@@ -49,11 +50,24 @@
 - 用来定义产品体验与宿主能力边界
 - 不作为当前仓库直接承诺支持的主宿主
 
+当前真实可行的接入面：
+
+- `cam mcp print-config --host claude`
+- `cam mcp doctor --host claude`
+- 用户手动维护 Claude host config
+
+当前明确不做：
+
+- `cam mcp install --host claude`
+- `cam integrations install/apply --host claude`
+- 自动写 Claude hooks / plugins / skills / subagent 资产
+
 ### Gemini CLI
 
 价值：
 
 - hooks、extensions、MCP、sub-agents 能力都很强
+- 官方公开 surface 已不只是 MCP config file，还包括 `settings.json`、`GEMINI.md`、memory、skills 与 extensions
 - 适合作为未来独立 memory runtime 的优先宿主之一
 
 在当前仓库里的角色：
@@ -61,6 +75,18 @@
 - **重要参考宿主**
 - 帮助当前仓库设计未来 skill / hook / MCP surfaces
 - 但不把当前仓库直接改写成 Gemini 主仓
+
+当前真实可行的接入面：
+
+- `cam mcp print-config --host gemini`
+- `cam mcp doctor --host gemini`
+- 用户手动维护 `.gemini/settings.json`
+
+当前明确不做：
+
+- `cam mcp install --host gemini`
+- `cam integrations install/apply --host gemini`
+- 自动写 Gemini hooks / skills / extensions / memory 配置
 
 ### OpenCode
 
@@ -99,6 +125,7 @@
 - `cam mcp doctor --host codex` 与 `cam integrations doctor --host codex` 现在还会把“偏好 route”和“当前可运行 route”分开表达：`recommendedRoute` 继续表示首选的 MCP-first 路径；`currentlyOperationalRoute`、`routeKind`、`routeEvidence`、`shellDependencyLevel`、`hostMutationRequired`、`preferredRouteBlockers`、`currentOperationalBlockers` 则表达当前环境里哪条 route 真正可跑、首选 route 为什么没跑起来、以及当前 fallback 自己是否还有 blocker。skills 继续被视为 guidance surface，而不是 executable fallback route
 - `cam integrations doctor --host codex` 还会显式暴露 skill-surface steering：`preferredSkillSurface`、`recommendedSkillInstallCommand`、`installedSkillSurfaces`、`readySkillSurfaces`。这些字段表达的是“当前建议把 guidance 安装到哪里”，而不是技能已经成为 executable fallback route。
 - release-facing `--help` 文案也视为宿主能力面的稳定公开接口，必须和上述 install / apply / doctor / manual-only 边界保持一致
+- 对 Claude / Gemini 这类非 Codex 宿主，当前仓库只承接 manual-only / snippet-first 接入，不把官方更强的 host-native surface 误写成本仓已经自动接管的能力
 
 不应该吸收：
 
@@ -114,6 +141,7 @@
 - 它当前服务于 Codex
 - 它会正式吸收 hooks、skills、MCP-aware integration 方向
 - 它不会在当前阶段直接承担多宿主统一平台职责
+- Claude / Gemini 当前都属于“公开能力值得研究，但本仓只支持 manual-only wiring guidance”的范围
 
 ## 与独立新仓的接口边界
 

--- a/docs/integration-strategy.md
+++ b/docs/integration-strategy.md
@@ -90,6 +90,7 @@
 - 当前推荐的渐进式检索 preset 统一为：`state=auto`、`limit=8`
 - `cam mcp install --host codex` 会显式写入推荐的 project-scoped Codex 宿主配置，继续降低接线摩擦，但不改变 retrieval 的只读语义；若已有 `codex_auto_memory` entry 带有非 canonical 自定义字段，会在安全前提下保留它们
 - `claude`、`gemini` 与 `generic` host 都保持 manual-only / snippet-first：不提供自动写入的 install 分支，只通过 `cam mcp print-config --host <claude|gemini|generic>` 暴露 ready-to-paste snippet
+- 这里的 manual-only 是有意的产品边界，不是“尚未补完的小缺口”：Claude Code 与 Gemini CLI 虽然都公开了比当前本仓接线更丰富的 host-native surface，但当前仓库仍然只承接 MCP wiring guidance，而不自动写它们的 host config、hooks、skills、extensions 或 memory-specific assets
 - `cam mcp print-config --host ...` 会打印 ready-to-paste 宿主接入片段；其中 `--host codex` 现在还会额外打印推荐的 `AGENTS.md` snippet，并在 JSON 输出里附带共享 `workflowContract`，把 durable memory workflow 正式接到 Codex 当前公开稳定 surface 上
 - `cam mcp apply-guidance --host codex` 会以 additive、可审计、fail-closed 的方式创建或更新 repo 根 `AGENTS.md` 中由本仓维护的 guidance block，继续降低手工粘贴成本
 - `cam integrations install --host codex` 现在提供显式的一次性 stack install 入口：统一编排 project-scoped MCP wiring、hooks 与 skills，但不触碰 `AGENTS.md`
@@ -132,6 +133,7 @@
 - 不为了宿主兼容而把当前仓库直接升格成统一多宿主主仓
 - 不围绕 plugin format 做统一抽象
 - 不把 hooks / skills / MCP 的引入理解成“放弃 CLI 主线”
+- 不把 Claude / Gemini 已公开的 host-native surface 直接翻译成本仓的自动安装承诺
 
 ## 当前仓库应该优先完成的产品面
 

--- a/src/lib/cli/register-commands.ts
+++ b/src/lib/cli/register-commands.ts
@@ -308,7 +308,8 @@ export function registerCommands(program: Command): void {
   program
     .command("init")
     .description("Initialize Codex Auto Memory in the current project")
-    .action(withStdout(async () => runInit()));
+    .option("--force", "Overwrite existing init config files with canonical defaults")
+    .action(withStdout(async (options) => runInit(options)));
 
   const memoryCommand = program
     .command("memory")

--- a/src/lib/cli/register-commands.ts
+++ b/src/lib/cli/register-commands.ts
@@ -327,6 +327,7 @@ export function registerCommands(program: Command): void {
     .option("--print-startup", "Print the compiled startup memory block")
     .option("--open", "Open the memory directory in the default file browser")
     .action(withStdout(async (options) => runMemory(options)));
+  memoryCommand.enablePositionalOptions();
 
   addJsonOption(
     memoryCommand
@@ -346,10 +347,23 @@ export function registerCommands(program: Command): void {
   ).action(
     withStdout(async (options, command) => {
       const parent = command.parent;
-      const mergedOptions =
-        typeof command.optsWithGlobals === "function"
-          ? (command.optsWithGlobals() as Record<string, unknown>)
-          : (command.opts() as Record<string, unknown>);
+      const subcommandOptions = command.opts() as Record<string, unknown>;
+      const subcommandJson =
+        command.getOptionValueSource("json") === "cli"
+          ? (subcommandOptions.json as boolean | undefined)
+          : undefined;
+      const subcommandCwd =
+        command.getOptionValueSource("cwd") === "cli"
+          ? (subcommandOptions.cwd as string | undefined)
+          : undefined;
+      const subcommandScope =
+        command.getOptionValueSource("scope") === "cli"
+          ? (subcommandOptions.scope as string | undefined)
+          : undefined;
+      const subcommandState =
+        command.getOptionValueSource("state") === "cli"
+          ? (subcommandOptions.state as string | undefined)
+          : undefined;
       const explicitParentOptions =
         parent
           ? Object.fromEntries(
@@ -370,15 +384,14 @@ export function registerCommands(program: Command): void {
           : {};
 
       return runMemoryReindex({
-        json: (options as { json?: boolean }).json ?? (mergedOptions.json as boolean | undefined),
-        cwd: (options as { cwd?: string }).cwd ?? (mergedOptions.cwd as string | undefined),
+        ...explicitParentOptions,
+        json: subcommandJson ?? (explicitParentOptions.json as boolean | undefined),
+        cwd: subcommandCwd ?? (explicitParentOptions.cwd as string | undefined),
         scope:
-          ((options as { scope?: string }).scope ??
-            (mergedOptions.scope as string | undefined)) as MemoryReindexCommandOptions["scope"],
-        state:
-          ((options as { state?: string }).state ??
-            (mergedOptions.state as string | undefined)) as MemoryReindexCommandOptions["state"],
-        ...explicitParentOptions
+          (subcommandScope ??
+            (explicitParentOptions.scope as string | undefined) ??
+            "all") as MemoryReindexCommandOptions["scope"],
+        state: (subcommandState ?? "all") as MemoryReindexCommandOptions["state"]
       });
     })
   );

--- a/src/lib/commands/init.ts
+++ b/src/lib/commands/init.ts
@@ -1,13 +1,41 @@
 import { configPaths } from "../config/load-config.js";
+import { rawProjectConfigSchema } from "../config/schema.js";
 import { MemoryStore } from "../domain/memory-store.js";
 import { detectProjectContext, getDefaultMemoryDirectory } from "../domain/project-context.js";
 import { SessionContinuityStore } from "../domain/session-continuity-store.js";
-import { updateGitignoreLine, writeJsonFile } from "../util/fs.js";
+import { buildRuntimeContext } from "../runtime/runtime-context.js";
+import { fileExists, readJsonFile, updateGitignoreLine, writeJsonFile } from "../util/fs.js";
 import type { AppConfig } from "../types.js";
 
 interface InitOptions {
   cwd?: string;
   force?: boolean;
+}
+
+async function ensureInitConfigShape(
+  filePath: string,
+  label: "project" | "local"
+): Promise<void> {
+  if (!(await fileExists(filePath))) {
+    return;
+  }
+
+  let raw: unknown;
+  try {
+    raw = await readJsonFile<unknown>(filePath);
+  } catch {
+    throw new Error(
+      `Existing ${label} config at ${filePath} is invalid. Re-run with --force to overwrite it.`
+    );
+  }
+
+  try {
+    rawProjectConfigSchema.parse(raw);
+  } catch {
+    throw new Error(
+      `Existing ${label} config at ${filePath} is invalid. Re-run with --force to overwrite it.`
+    );
+  }
 }
 
 export async function runInit(options: InitOptions = {}): Promise<string> {
@@ -26,18 +54,29 @@ export async function runInit(options: InitOptions = {}): Promise<string> {
     codexBinary: "codex"
   };
 
-  await writeJsonFile(projectConfigPath, projectConfig);
-  await writeJsonFile(localConfigPath, {
-    autoMemoryEnabled: true
-  });
+  if (!options.force) {
+    await ensureInitConfigShape(projectConfigPath, "project");
+    await ensureInitConfigShape(localConfigPath, "local");
+  }
+
+  if (options.force || !(await fileExists(projectConfigPath))) {
+    await writeJsonFile(projectConfigPath, projectConfig);
+  }
+  if (options.force || !(await fileExists(localConfigPath))) {
+    await writeJsonFile(localConfigPath, {
+      autoMemoryEnabled: true
+    });
+  }
   await updateGitignoreLine(project.projectRoot, ".codex-auto-memory.local.json");
 
-  const config: AppConfig = {
-    ...projectConfig,
-    autoMemoryDirectory: getDefaultMemoryDirectory()
-  };
+  const runtime = await buildRuntimeContext(project.projectRoot);
+  const config: AppConfig = runtime.loadedConfig.config.autoMemoryDirectory
+    ? runtime.loadedConfig.config
+    : {
+        ...runtime.loadedConfig.config,
+        autoMemoryDirectory: getDefaultMemoryDirectory()
+      };
   const store = new MemoryStore(project, config);
-  await store.ensureLayout();
   const continuityStore = new SessionContinuityStore(project, config);
   const excludePath = await continuityStore.ensureLocalIgnore();
 

--- a/src/lib/commands/init.ts
+++ b/src/lib/commands/init.ts
@@ -3,8 +3,8 @@ import { rawProjectConfigSchema } from "../config/schema.js";
 import { MemoryStore } from "../domain/memory-store.js";
 import { detectProjectContext, getDefaultMemoryDirectory } from "../domain/project-context.js";
 import { SessionContinuityStore } from "../domain/session-continuity-store.js";
-import { buildRuntimeContext } from "../runtime/runtime-context.js";
 import { fileExists, readJsonFile, updateGitignoreLine, writeJsonFile } from "../util/fs.js";
+import { resolveAppPath } from "../util/paths.js";
 import type { AppConfig } from "../types.js";
 
 interface InitOptions {
@@ -69,13 +69,20 @@ export async function runInit(options: InitOptions = {}): Promise<string> {
   }
   await updateGitignoreLine(project.projectRoot, ".codex-auto-memory.local.json");
 
-  const runtime = await buildRuntimeContext(project.projectRoot);
-  const config: AppConfig = runtime.loadedConfig.config.autoMemoryDirectory
-    ? runtime.loadedConfig.config
-    : {
-        ...runtime.loadedConfig.config,
-        autoMemoryDirectory: getDefaultMemoryDirectory()
-      };
+  const persistedProjectConfig = rawProjectConfigSchema.parse(
+    (await readJsonFile(projectConfigPath)) ?? projectConfig
+  );
+  const persistedLocalConfig = rawProjectConfigSchema.parse(
+    (await readJsonFile(localConfigPath)) ?? { autoMemoryEnabled: true }
+  );
+  const config: AppConfig = {
+    ...projectConfig,
+    ...persistedProjectConfig,
+    ...persistedLocalConfig,
+    autoMemoryDirectory: persistedLocalConfig.autoMemoryDirectory
+      ? resolveAppPath(persistedLocalConfig.autoMemoryDirectory)
+      : getDefaultMemoryDirectory()
+  };
   const store = new MemoryStore(project, config);
   const continuityStore = new SessionContinuityStore(project, config);
   const excludePath = await continuityStore.ensureLocalIgnore();

--- a/src/lib/commands/integrations.ts
+++ b/src/lib/commands/integrations.ts
@@ -242,11 +242,21 @@ async function restoreRollbackSnapshots(snapshots: FileRollbackSnapshot[]): Prom
 
     try {
       await ensureDir(path.dirname(snapshot.path));
-      await fs.rm(snapshot.path, { force: true, recursive: true }).catch(() => undefined);
+      if (snapshot.kind === "directory") {
+        const currentStat = await fs.lstat(snapshot.path).catch(() => null);
+        if (!currentStat?.isDirectory()) {
+          await fs.rm(snapshot.path, { force: true, recursive: true }).catch(() => undefined);
+          await ensureDir(snapshot.path);
+        }
+        if (snapshot.mode !== null) {
+          await fs.chmod(snapshot.path, snapshot.mode);
+        }
+      } else {
+        await fs.rm(snapshot.path, { force: true, recursive: true }).catch(() => undefined);
+      }
       if (snapshot.kind === "symlink") {
         await fs.symlink(snapshot.symlinkTarget ?? "", snapshot.path);
       } else if (snapshot.kind === "directory") {
-        await ensureDir(snapshot.path);
         if (snapshot.mode !== null) {
           await fs.chmod(snapshot.path, snapshot.mode);
         }
@@ -465,6 +475,33 @@ function buildInstallFailureSubaction(
   };
 }
 
+type ApplyFailureSubactionName = "mcp" | "agents" | "hooks" | "skills";
+
+function inferFailedApplySubaction(
+  mcpResult: Awaited<ReturnType<typeof installMcpProjectConfig>> | null,
+  hooksResult: Awaited<ReturnType<typeof installIntegrationAssets>> | null,
+  skillsResult: Awaited<ReturnType<typeof installIntegrationAssets>> | null,
+  agentsResult: Awaited<ReturnType<typeof applyCodexAgentsGuidance>> | null
+): ApplyFailureSubactionName | null {
+  if (!mcpResult) {
+    return "mcp";
+  }
+
+  if (!hooksResult) {
+    return "hooks";
+  }
+
+  if (!skillsResult) {
+    return "skills";
+  }
+
+  if (!agentsResult) {
+    return "agents";
+  }
+
+  return null;
+}
+
 function buildApplyFailureSubaction(
   result:
     | Awaited<ReturnType<typeof installMcpProjectConfig>>
@@ -472,12 +509,26 @@ function buildApplyFailureSubaction(
     | Awaited<ReturnType<typeof applyCodexAgentsGuidance>>
     | null,
   options: {
+    currentSubaction: ApplyFailureSubactionName;
+    failedSubaction: ApplyFailureSubactionName | null;
     fallbackSurface?: CodexSkillInstallSurface;
+    failureMessage: string;
     skipReason: string;
     rollbackSucceeded: boolean;
   }
 ): IntegrationSubactionResult {
   if (!result) {
+    if (options.currentSubaction === options.failedSubaction) {
+      return {
+        status: "blocked",
+        action: "blocked",
+        attempted: true,
+        surface: options.fallbackSurface,
+        readOnlyRetrieval: true,
+        notes: [options.failureMessage]
+      };
+    }
+
     return {
       status: "ok",
       action: "unchanged",
@@ -1166,23 +1217,45 @@ export async function runIntegrationsApply(
           cwd: projectRoot
         }),
         subactions: {
+          ...(function () {
+            const failedSubaction = inferFailedApplySubaction(
+              mcpResult,
+              hooksResult,
+              skillsResult,
+              agentsResult
+            );
+            return {
           mcp: buildApplyFailureSubaction(mcpResult, {
+            currentSubaction: "mcp",
+            failedSubaction,
             rollbackSucceeded,
+            failureMessage,
             skipReason
           }),
           agents: buildApplyFailureSubaction(agentsResult, {
+            currentSubaction: "agents",
+            failedSubaction,
             rollbackSucceeded,
+            failureMessage,
             skipReason
           }),
           hooks: buildApplyFailureSubaction(hooksResult, {
+            currentSubaction: "hooks",
+            failedSubaction,
             rollbackSucceeded,
+            failureMessage,
             skipReason
           }),
           skills: buildApplyFailureSubaction(skillsResult, {
+            currentSubaction: "skills",
+            failedSubaction,
             fallbackSurface: skillSurface,
             rollbackSucceeded,
+            failureMessage,
             skipReason
           })
+            };
+          })()
         },
         notes: [
           "This orchestration surface is Codex-only and explicit.",

--- a/src/lib/commands/manual-mutation-review.ts
+++ b/src/lib/commands/manual-mutation-review.ts
@@ -187,7 +187,12 @@ function buildNextRecommendedActions(
       )
     );
   } else {
-    steps.push("Details are unavailable for deleted refs; use cam recall timeline to review the deletion trail.");
+    steps.push(
+      `Details are unavailable for deleted refs; review the deletion trail with ${buildResolvedCliTimelineCommand(
+        JSON.stringify(timelineRefs[0]),
+        options
+      )}.`
+    );
   }
 
   steps.push(

--- a/src/lib/commands/mcp.ts
+++ b/src/lib/commands/mcp.ts
@@ -10,6 +10,7 @@ import {
 import { installMcpProjectConfig } from "../integration/mcp-install.js";
 import { formatMcpDoctorReport, inspectMcpDoctor } from "../integration/mcp-doctor.js";
 import { startRetrievalMcpServer } from "../mcp/retrieval-server.js";
+import { ensureExistingDirectory } from "../util/paths.js";
 
 interface McpServeOptions {
   cwd?: string;
@@ -39,17 +40,25 @@ interface McpApplyGuidanceOptions {
   json?: boolean;
 }
 
-function resolveCommandCwd(cwd: string | undefined): string {
-  return cwd ? path.resolve(cwd) : process.cwd();
+async function resolveCommandCwd(cwd: string | undefined): Promise<string> {
+  if (cwd === undefined) {
+    return process.cwd();
+  }
+
+  if (!cwd.trim()) {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  return ensureExistingDirectory(path.resolve(cwd));
 }
 
 export async function runMcpServe(options: McpServeOptions = {}): Promise<void> {
-  await startRetrievalMcpServer(resolveCommandCwd(options.cwd));
+  await startRetrievalMcpServer(await resolveCommandCwd(options.cwd));
 }
 
 export async function runMcpPrintConfig(options: McpPrintConfigOptions = {}): Promise<string> {
   const host = normalizeMcpHost(options.host);
-  const projectRoot = resolveMcpProjectRoot(resolveCommandCwd(options.cwd));
+  const projectRoot = resolveMcpProjectRoot(await resolveCommandCwd(options.cwd));
   const snippet = buildMcpHostConfigSnippet(host, projectRoot);
 
   if (options.json) {
@@ -61,7 +70,7 @@ export async function runMcpPrintConfig(options: McpPrintConfigOptions = {}): Pr
 
 export async function runMcpDoctor(options: McpDoctorOptions = {}): Promise<string> {
   const report = await inspectMcpDoctor({
-    cwd: resolveCommandCwd(options.cwd),
+    cwd: await resolveCommandCwd(options.cwd),
     host: options.host,
     explicitCwd: Boolean(options.cwd)
   });
@@ -75,7 +84,7 @@ export async function runMcpDoctor(options: McpDoctorOptions = {}): Promise<stri
 
 export async function runMcpInstall(options: McpInstallOptions = {}): Promise<string> {
   const host = normalizeMcpHost(options.host);
-  const projectRoot = resolveMcpProjectRoot(resolveCommandCwd(options.cwd));
+  const projectRoot = resolveMcpProjectRoot(await resolveCommandCwd(options.cwd));
   const result = await installMcpProjectConfig(host, projectRoot);
 
   if (options.json) {
@@ -103,7 +112,7 @@ export async function runMcpApplyGuidance(
     );
   }
 
-  const projectRoot = resolveMcpProjectRoot(resolveCommandCwd(options.cwd));
+  const projectRoot = resolveMcpProjectRoot(await resolveCommandCwd(options.cwd));
   const result = await applyCodexAgentsGuidance(projectRoot);
 
   if (options.json) {

--- a/src/lib/commands/session.ts
+++ b/src/lib/commands/session.ts
@@ -170,10 +170,10 @@ export async function runSession(
   options: SessionOptions = {}
 ): Promise<string> {
   const cwd = options.cwd ?? process.cwd();
-  const runtime = await buildRuntimeContext(cwd);
   const scope = selectedScope(options.scope);
 
   if (action === "save" || action === "refresh") {
+    const runtime = await buildRuntimeContext(cwd);
     const persistenceRequest = await prepareSessionPersistenceRequest(
       runtime,
       action,
@@ -197,6 +197,7 @@ export async function runSession(
   }
 
   if (action === "clear") {
+    const runtime = await buildRuntimeContext(cwd);
     const cleared = await runtime.sessionContinuityStore.clear(scope);
     if (options.json) {
       return JSON.stringify({ cleared }, null, 2);
@@ -210,6 +211,7 @@ export async function runSession(
   }
 
   if (action === "open") {
+    const runtime = await buildRuntimeContext(cwd);
     await runtime.sessionContinuityStore.ensureLocalLayout();
     openPath(runtime.sessionContinuityStore.paths.localDir);
     return [
@@ -218,6 +220,9 @@ export async function runSession(
     ].join("\n");
   }
 
+  const runtime = await buildRuntimeContext(cwd, {}, {
+    ensureMemoryLayout: false
+  });
   const view = await loadSessionInspectionView(runtime);
 
   if (action === "load") {

--- a/src/lib/commands/session.ts
+++ b/src/lib/commands/session.ts
@@ -123,20 +123,20 @@ async function selectSaveRollout(
     };
   }
 
+  const latestPrimaryRollout = await findLatestProjectRollout(runtime.project);
+  if (latestPrimaryRollout) {
+    return {
+      kind: "latest-primary-rollout",
+      rolloutPath: latestPrimaryRollout
+    };
+  }
+
   const latestAuditEntry =
     await runtime.sessionContinuityStore.readLatestAuditEntryMatchingScope(scope);
   if (latestAuditEntry) {
     return {
       kind: "latest-audit-entry",
       rolloutPath: latestAuditEntry.rolloutPath
-    };
-  }
-
-  const latestPrimaryRollout = await findLatestProjectRollout(runtime.project);
-  if (latestPrimaryRollout) {
-    return {
-      kind: "latest-primary-rollout",
-      rolloutPath: latestPrimaryRollout
     };
   }
 

--- a/src/lib/domain/recovery-records.ts
+++ b/src/lib/domain/recovery-records.ts
@@ -394,6 +394,6 @@ export function matchesContinuityRecoveryRecord(
     record.worktreeId === identity.worktreeId &&
     record.rolloutPath === identity.rolloutPath &&
     record.sourceSessionId === identity.sourceSessionId &&
-    record.scope === identity.scope
+    (record.scope === identity.scope || (record.scope === "both" && identity.scope !== "both"))
   );
 }

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -51,7 +51,8 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
         .map((segment) => slugify(segment))
         .filter(Boolean);
       const hostContextToken =
-        hostTokens.find((token) => !genericHostTokens.has(token)) ?? slugify(parsed.hostname);
+        hostTokens.filter((token) => !genericHostTokens.has(token)).join("-") ||
+        slugify(parsed.hostname);
       const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -35,10 +35,6 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
       .map((segment) => slugify(segment))
       .filter(Boolean);
     const tailToken = [...pathTokens].reverse().find(Boolean);
-    if (tailToken && !genericReferenceTokens.has(tailToken)) {
-      return tailToken;
-    }
-
     if (category === "issue-tracker") {
       const ticketToken =
         [...pathTokens].reverse().find((token) => /^[a-z]+-\d+$/iu.test(token) || /^\d+$/u.test(token)) ??
@@ -59,6 +55,10 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
       const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;
+    }
+
+    if (tailToken && !genericReferenceTokens.has(tailToken)) {
+      return tailToken;
     }
 
     if (tailToken) {

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -30,6 +30,8 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
     const parsed = new URL(url);
     const pathTokens = parsed.pathname
       .split("/")
+      .map((segment) => segment.trim())
+      .filter(Boolean)
       .map((segment) => slugify(segment))
       .filter(Boolean);
     const tailToken = [...pathTokens].reverse().find(Boolean);
@@ -38,6 +40,9 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
     }
 
     if (category === "issue-tracker") {
+      const ticketToken =
+        [...pathTokens].reverse().find((token) => /^[a-z]+-\d+$/iu.test(token) || /^\d+$/u.test(token)) ??
+        null;
       const nonGenericPathTokens = pathTokens.filter((token) => {
         if (genericReferenceTokens.has(token)) {
           return false;
@@ -51,7 +56,7 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
         .filter(Boolean);
       const hostContextToken =
         hostTokens.find((token) => !genericHostTokens.has(token)) ?? slugify(parsed.hostname);
-      const contextToken = nonGenericPathTokens.slice(-2).join("-");
+      const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;
     }

--- a/src/lib/integration/assets.ts
+++ b/src/lib/integration/assets.ts
@@ -123,7 +123,8 @@ function resolveInstallDir(
 
 function buildProjectRootResolutionBlock(projectRoot?: string): string {
   if (projectRoot) {
-    return `PROJECT_ROOT=${JSON.stringify(projectRoot)}
+    const escapedProjectRoot = projectRoot.replace(/'/g, "'\"'\"'");
+    return `PROJECT_ROOT='${escapedProjectRoot}'
 `;
   }
 

--- a/src/lib/integration/mcp-config.ts
+++ b/src/lib/integration/mcp-config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { detectProjectContext } from "../domain/project-context.js";
 import {
@@ -36,8 +37,28 @@ export interface McpHostConfigSnippet {
 
 export { normalizeMcpHost };
 
+export function resolveMcpProjectCwd(cwd = process.cwd()): string {
+  if (!cwd.trim()) {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  const resolved = path.resolve(cwd);
+  let stat;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  if (!stat.isDirectory()) {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  return resolved;
+}
+
 export function resolveMcpProjectRoot(cwd = process.cwd()): string {
-  return detectProjectContext(path.resolve(cwd)).projectRoot;
+  return detectProjectContext(resolveMcpProjectCwd(cwd)).projectRoot;
 }
 
 export function buildMcpHostConfigSnippet(host: McpHost, projectRoot: string): McpHostConfigSnippet {

--- a/src/lib/integration/mcp-doctor.ts
+++ b/src/lib/integration/mcp-doctor.ts
@@ -51,7 +51,7 @@ import {
 } from "./skills-paths.js";
 import { fileExists, readTextFile } from "../util/fs.js";
 import { buildRuntimeContext } from "../runtime/runtime-context.js";
-import { resolveMcpProjectRoot } from "./mcp-config.js";
+import { resolveMcpProjectCwd, resolveMcpProjectRoot } from "./mcp-config.js";
 import type { RetrievalSidecarCheck } from "../domain/memory-store.js";
 import type { MemoryLayoutDiagnostic, TopicFileDiagnostic } from "../types.js";
 
@@ -1131,7 +1131,9 @@ export async function inspectMcpDoctor(options: {
   host?: string;
   explicitCwd?: boolean;
 } = {}): Promise<McpDoctorReport> {
-  const cwd = await normalizeComparablePath(options.cwd ?? process.cwd());
+  const cwd = await normalizeComparablePath(
+    options.cwd === undefined ? process.cwd() : resolveMcpProjectCwd(options.cwd)
+  );
   const projectRoot = resolveMcpProjectRoot(cwd);
   const agentsGuidancePath = path.join(projectRoot, "AGENTS.md");
   const hostSelection: McpDoctorHostSelection = normalizeMcpDoctorHostSelection(options.host);

--- a/src/lib/integration/retrieval-contract.ts
+++ b/src/lib/integration/retrieval-contract.ts
@@ -249,12 +249,16 @@ export function hasCliCwdFlag(command: string): boolean {
   return /(?:^|\s)--cwd(?:\s|=)/u.test(command);
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
 export function appendCliCwdFlag(command: string, cwd?: string): string {
   if (!cwd || hasCliCwdFlag(command)) {
     return command;
   }
 
-  return `${command} --cwd ${JSON.stringify(cwd)}`;
+  return `${command} --cwd ${shellQuote(cwd)}`;
 }
 
 export function buildResolvedCliCommand(
@@ -277,10 +281,10 @@ function buildHookFallbackCommand(
     cwd?: string;
   } = {}
 ): string {
-  const helperPath = JSON.stringify(getInstalledHookHelperPath("memory-recall.sh"));
+  const helperPath = shellQuote(getInstalledHookHelperPath("memory-recall.sh"));
   const invocation = `${helperPath} ${action} ${argumentPlaceholder}`;
   return options.cwd
-    ? `CAM_PROJECT_ROOT=${JSON.stringify(options.cwd)} ${invocation}`
+    ? `CAM_PROJECT_ROOT=${shellQuote(options.cwd)} ${invocation}`
     : invocation;
 }
 

--- a/src/lib/integration/retrieval-contract.ts
+++ b/src/lib/integration/retrieval-contract.ts
@@ -41,6 +41,7 @@ export const MCP_SERVE_GUIDANCE =
 export function buildMcpDoctorGuidance(
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   const fallbackCommand = buildResolvedCliCommand("mcp doctor --host codex", options);
@@ -55,6 +56,7 @@ export const ARCHIVE_BOUNDARY =
 export function buildDurableMemorySyncGuidance(
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   const syncCommand = buildResolvedPostWorkSyncCommand(options);
@@ -265,9 +267,11 @@ export function buildResolvedCliCommand(
   command: string,
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
-  return appendCliCwdFlag(`${resolveCliLauncher().resolvedCommand} ${command}`, options.cwd);
+  const launcher = options.launcherOverride ?? resolveCliLauncher();
+  return appendCliCwdFlag(`${launcher.resolvedCommand} ${command}`, options.cwd);
 }
 
 function getInstalledHookHelperPath(helperScript: string): string {
@@ -353,6 +357,7 @@ export function buildResolvedCliSearchCommand(
     state?: MemoryRetrievalStateFilter;
     limit?: number;
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   const state = options.state ?? RECOMMENDED_RETRIEVAL_STATE;
@@ -367,6 +372,7 @@ export function buildResolvedCliTimelineCommand(
   ref = "\"<ref>\"",
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   return buildResolvedCliCommand(`recall timeline ${ref}`, options);
@@ -376,6 +382,7 @@ export function buildResolvedCliDetailsCommand(
   ref = "\"<ref>\"",
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   return buildResolvedCliCommand(`recall details ${ref}`, options);
@@ -384,6 +391,7 @@ export function buildResolvedCliDetailsCommand(
 export function buildResolvedPostWorkSyncCommand(
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   return buildResolvedCliCommand("sync", options);
@@ -392,6 +400,7 @@ export function buildResolvedPostWorkSyncCommand(
 export function buildResolvedPostWorkRecentReviewCommand(
   options: {
     cwd?: string;
+    launcherOverride?: WorkflowContract["launcher"];
   } = {}
 ): string {
   return buildResolvedCliCommand("memory --recent", options);
@@ -410,7 +419,7 @@ export function buildWorkflowContract(
     localBridge: LOCAL_BRIDGE_RECALL_WORKFLOW,
     resolvedCli: RESOLVED_CLI_RECALL_WORKFLOW,
     cliFallback: CLI_FALLBACK_RECALL_WORKFLOW,
-    doctor: buildMcpDoctorGuidance(options),
+    doctor: buildMcpDoctorGuidance({ ...options, launcherOverride: launcher }),
     serve: MCP_SERVE_GUIDANCE
   };
   const recallWorkflow: WorkflowRecallWorkflow = {
@@ -439,21 +448,33 @@ export function buildWorkflowContract(
     requiresCamOnPath: true
   };
   const resolvedCliFallback: WorkflowContract["resolvedCliFallback"] = {
-    searchCommand: buildResolvedCliSearchCommand("\"<query>\"", options),
-    timelineCommand: buildResolvedCliTimelineCommand("\"<ref>\"", options),
-    detailsCommand: buildResolvedCliDetailsCommand("\"<ref>\"", options)
+    searchCommand: buildResolvedCliSearchCommand("\"<query>\"", {
+      ...options,
+      launcherOverride: launcher
+    }),
+    timelineCommand: buildResolvedCliTimelineCommand("\"<ref>\"", {
+      ...options,
+      launcherOverride: launcher
+    }),
+    detailsCommand: buildResolvedCliDetailsCommand("\"<ref>\"", {
+      ...options,
+      launcherOverride: launcher
+    })
   };
   const postWorkSyncReview: WorkflowContract["postWorkSyncReview"] = {
     helperScript: POST_WORK_SYNC_REVIEW_HELPER,
     syncCommand: buildPostWorkSyncCommand(options),
     reviewCommand: buildPostWorkRecentReviewCommand(options),
-    guidance: buildDurableMemorySyncGuidance(options),
+    guidance: buildDurableMemorySyncGuidance({ ...options, launcherOverride: launcher }),
     shellOnly: true,
     requiresCamOnPath: true
   };
   const resolvedPostWorkSyncReview: WorkflowContract["resolvedPostWorkSyncReview"] = {
-    syncCommand: buildResolvedPostWorkSyncCommand(options),
-    reviewCommand: buildResolvedPostWorkRecentReviewCommand(options)
+    syncCommand: buildResolvedPostWorkSyncCommand({ ...options, launcherOverride: launcher }),
+    reviewCommand: buildResolvedPostWorkRecentReviewCommand({
+      ...options,
+      launcherOverride: launcher
+    })
   };
   const boundaries: WorkflowContract["boundaries"] = {
     memoryAudit: MEMORY_AUDIT_BOUNDARY,

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -580,7 +580,7 @@ describe("dist cli smoke", () => {
           preferredRoute: "mcp-first"
         },
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
         }
       },
       agentsGuidance: {
@@ -1202,7 +1202,7 @@ describe("dist cli smoke", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
         }
       },
       subactions: {
@@ -1246,7 +1246,7 @@ describe("dist cli smoke", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
         }
       },
       subactions: {
@@ -1379,7 +1379,7 @@ describe("dist cli smoke", () => {
       failureMessage: expect.stringContaining("directory"),
       rollbackApplied: true,
       subactions: {
-        mcp: { attempted: false },
+        mcp: { attempted: true, status: "blocked", action: "blocked" },
         agents: { attempted: false },
         hooks: { attempted: false },
         skills: { attempted: false }

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1694,6 +1694,24 @@ describe("dist cli smoke", () => {
     });
   });
 
+  it("fails closed for invalid --cwd on the compiled integrations doctor entrypoint", async () => {
+    const homeDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-home-");
+    const projectDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-project-");
+
+    for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
+      const result = runCli(
+        projectDir,
+        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
+        {
+          entrypoint: "dist",
+          env: { HOME: homeDir }
+        }
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
+
   it("routes exec through the compiled wrapper entrypoint", async () => {
     const repoDir = await tempDir("cam-dist-wrapper-repo-");
     const homeDir = await tempDir("cam-dist-wrapper-home-");

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1283,7 +1283,7 @@ describe("dist cli smoke", () => {
       failureMessage: expect.stringContaining("directory"),
       rollbackApplied: true,
       subactions: {
-        mcp: { attempted: false },
+        mcp: { attempted: true, status: "blocked", action: "blocked" },
         agents: { attempted: false },
         hooks: { attempted: false },
         skills: { attempted: false }

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -55,6 +55,15 @@ async function waitForFile(pathname: string, timeoutMs = 2_000): Promise<string>
   }
 }
 
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 afterEach(async () => {
   if (originalCodexHome === undefined) {
     delete process.env.CODEX_HOME;
@@ -297,6 +306,68 @@ describe("dist cli smoke", () => {
     expect(forgetPayload.followUp.timelineRefs.length).toBeGreaterThan(0);
     expect(forgetPayload.followUp.timelineRefs.length).toBeGreaterThan(0);
   }, 30_000);
+
+  it("keeps session inspection read-only from the compiled cli entrypoint", async () => {
+    const homeDir = await tempDir("cam-dist-session-readonly-home-");
+    const projectDir = await tempDir("cam-dist-session-readonly-project-");
+    const memoryRootParent = await tempDir("cam-dist-session-readonly-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+
+    await writeCamConfig(projectDir, makeAppConfig(), {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const sessionStatusResult = runCli(projectDir, ["session", "status", "--json"], {
+      entrypoint: "dist",
+      env: { HOME: homeDir }
+    });
+    const sessionLoadResult = runCli(
+      projectDir,
+      ["session", "load", "--json", "--print-startup"],
+      {
+        entrypoint: "dist",
+        env: { HOME: homeDir }
+      }
+    );
+
+    expect(sessionStatusResult.exitCode, sessionStatusResult.stderr).toBe(0);
+    expect(sessionLoadResult.exitCode, sessionLoadResult.stderr).toBe(0);
+    expect(JSON.parse(sessionStatusResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(JSON.parse(sessionLoadResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(await pathExists(memoryRoot)).toBe(false);
+  });
 
   it("uses the recommended recall search preset from the compiled cli entrypoint without creating memory layout on first lookup", async () => {
     const homeDir = await tempDir("cam-dist-recall-home-");

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1694,21 +1694,26 @@ describe("dist cli smoke", () => {
     });
   });
 
-  it("fails closed for invalid --cwd on the compiled integrations doctor entrypoint", async () => {
+  it("fails closed for invalid --cwd on compiled integrations entrypoints", async () => {
     const homeDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-home-");
     const projectDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-project-");
 
-    for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
-      const result = runCli(
-        projectDir,
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        {
-          entrypoint: "dist",
-          env: { HOME: homeDir }
-        }
-      );
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
+        const result = runCli(
+          projectDir,
+          [...command, "--cwd", cwd],
+          {
+            entrypoint: "dist",
+            env: { HOME: homeDir }
+          }
+        );
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+      }
     }
   });
 

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -1282,6 +1282,90 @@ describe("HeuristicExtractor", () => {
     );
   });
 
+  it("does not collapse repo-specific issue URLs that share the same numeric issue id", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "widgets-issues",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://github.com/acme/widgets/issues/123",
+        details: ["Primary widgets issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://github.com/acme/api/issues/123."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "widgets-issues"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://github.com/acme/api/issues/123"
+        })
+      ])
+    );
+  });
+
+  it("does not collapse same-host issue tracker URLs that use distinct ticket ids", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "jira-auth-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://jira.example.com/browse/AUTH-123",
+        details: ["Primary auth issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://jira.example.com/browse/PLAT-456."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "jira-auth-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://jira.example.com/browse/PLAT-456"
+        })
+      ])
+    );
+  });
+
   it("does not suppress different issue tracker URLs when both use a generic browse tail", () => {
     const reviewed = reviewExtractedMemoryOperations(
       [

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -1366,6 +1366,93 @@ describe("HeuristicExtractor", () => {
     );
   });
 
+  it("does not collapse cross-host issue tracker URLs that share the same repo path and ticket id", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "github-foo-widgets-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://github.foo.example.com/acme/widgets/issues/123",
+        details: ["Primary GitHub Enterprise tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: [
+          "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123."
+        ]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "github-foo-widgets-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary:
+            "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123"
+        })
+      ])
+    );
+  });
+
+  it("does not collapse cross-host issue tracker URLs that share the same ticket id behind a generic browse path", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "jira-foo-auth-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://jira.foo.example.com/browse/AUTH-123",
+        details: ["Primary Jira issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://jira.bar.example.com/browse/AUTH-123."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "jira-foo-auth-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://jira.bar.example.com/browse/AUTH-123"
+        })
+      ])
+    );
+  });
+
   it("does not suppress different issue tracker URLs when both use a generic browse tail", () => {
     const reviewed = reviewExtractedMemoryOperations(
       [

--- a/test/hooks-command.test.ts
+++ b/test/hooks-command.test.ts
@@ -202,7 +202,7 @@ describe("hooks command", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(await fs.realpath(projectDir))}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${await fs.realpath(projectDir)}'`
         },
         postWorkSyncReview: {
           helperScript: "post-work-memory-review.sh"

--- a/test/hooks-command.test.ts
+++ b/test/hooks-command.test.ts
@@ -48,7 +48,21 @@ afterEach(async () => {
 });
 
 describe("hooks command", () => {
-  it("supports --cwd while keeping generated hook helpers reusable across projects", async () => {
+  it("fails closed when --cwd is empty, whitespace-only, or missing", async () => {
+    const homeDir = await tempDir("cam-hooks-empty-cwd-home-");
+    const projectDir = await tempDir("cam-hooks-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const cwd of ["", "   ", missingDir]) {
+      const result = runCli(projectDir, ["hooks", "install", "--cwd", cwd], {
+        env: { HOME: homeDir }
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
+  shellOnlyIt("supports --cwd while keeping generated hook helpers reusable across projects", async () => {
     const homeDir = await tempDir("cam-hooks-cwd-home-");
     const projectParentDir = await tempDir("cam-hooks-cwd-parent-");
     const projectDir = path.join(projectParentDir, "project with spaces");

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initGitRepo,
+  writeCamConfig
+} from "./helpers/cam-test-fixtures.js";
+import { runCli } from "./helpers/cli-runner.js";
+
+const tempDirs: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+}
+
+const expectedProjectInitConfig = {
+  autoMemoryEnabled: true,
+  extractorMode: "codex",
+  defaultScope: "project",
+  maxStartupLines: 200,
+  sessionContinuityAutoLoad: false,
+  sessionContinuityAutoSave: false,
+  sessionContinuityLocalPathStyle: "codex",
+  maxSessionContinuityLines: 60,
+  codexBinary: "codex"
+};
+
+const expectedLocalInitConfig = {
+  autoMemoryEnabled: true
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("cam init", () => {
+  it("keeps existing valid init config files by default", async () => {
+    const homeDir = await tempDir("cam-init-home-");
+    const repoDir = await tempDir("cam-init-repo-");
+    const customMemoryRoot = await tempDir("cam-init-custom-memory-");
+    await initGitRepo(repoDir);
+
+    const existingProjectConfig = {
+      ...expectedProjectInitConfig,
+      defaultScope: "project-local",
+      sessionContinuityAutoLoad: true,
+      codexBinary: "codex-dev"
+    };
+    const existingLocalConfig = {
+      autoMemoryEnabled: false,
+      autoMemoryDirectory: customMemoryRoot,
+      sessionContinuityAutoSave: true
+    };
+    await writeCamConfig(repoDir, existingProjectConfig, existingLocalConfig);
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(existingProjectConfig);
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(existingLocalConfig);
+    expect(await pathExists(customMemoryRoot)).toBe(true);
+    expect(await fs.readFile(path.join(repoDir, ".gitignore"), "utf8")).toContain(
+      ".codex-auto-memory.local.json"
+    );
+    expect(await fs.readFile(path.join(repoDir, ".git", "info", "exclude"), "utf8")).toContain(
+      ".codex-auto-memory/"
+    );
+  });
+
+  it("overwrites existing init config files when --force is passed", async () => {
+    const homeDir = await tempDir("cam-init-force-home-");
+    const repoDir = await tempDir("cam-init-force-repo-");
+    const customMemoryRoot = await tempDir("cam-init-force-custom-memory-");
+    await initGitRepo(repoDir);
+
+    await writeCamConfig(
+      repoDir,
+      {
+        ...expectedProjectInitConfig,
+        defaultScope: "project-local",
+        codexBinary: "codex-dev"
+      },
+      {
+        autoMemoryEnabled: false,
+        autoMemoryDirectory: customMemoryRoot
+      }
+    );
+
+    const result = runCli(repoDir, ["init", "--force"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
+      expectedLocalInitConfig
+    );
+  });
+
+  it("fails closed on invalid existing init config without --force", async () => {
+    const homeDir = await tempDir("cam-init-invalid-home-");
+    const repoDir = await tempDir("cam-init-invalid-repo-");
+    const memoryRootParent = await tempDir("cam-init-invalid-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "codex-auto-memory.json"), "{\n", "utf8");
+    await fs.writeFile(
+      path.join(repoDir, ".codex-auto-memory.local.json"),
+      JSON.stringify({ autoMemoryDirectory: memoryRoot }, null, 2),
+      "utf8"
+    );
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Re-run with --force");
+    expect(await fs.readFile(path.join(repoDir, "codex-auto-memory.json"), "utf8")).toBe("{\n");
+    expect(await pathExists(memoryRoot)).toBe(false);
+  });
+
+  it("rebuilds invalid existing init config when --force is passed", async () => {
+    const homeDir = await tempDir("cam-init-rebuild-home-");
+    const repoDir = await tempDir("cam-init-rebuild-repo-");
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "codex-auto-memory.json"), "{\n", "utf8");
+    await fs.writeFile(path.join(repoDir, ".codex-auto-memory.local.json"), "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init", "--force"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
+      expectedLocalInitConfig
+    );
+  });
+});

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -9,6 +9,8 @@ import {
 import { runCli } from "./helpers/cli-runner.js";
 
 const tempDirs: string[] = [];
+const originalHome = process.env.HOME;
+const originalManagedConfig = process.env.CAM_MANAGED_CONFIG;
 
 async function tempDir(prefix: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", prefix));
@@ -46,6 +48,12 @@ const expectedLocalInitConfig = {
 };
 
 afterEach(async () => {
+  process.env.HOME = originalHome;
+  if (originalManagedConfig === undefined) {
+    delete process.env.CAM_MANAGED_CONFIG;
+  } else {
+    process.env.CAM_MANAGED_CONFIG = originalManagedConfig;
+  }
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -166,6 +174,7 @@ describe("cam init", () => {
     const homeDir = await tempDir("cam-init-invalid-user-home-");
     const repoDir = await tempDir("cam-init-invalid-user-repo-");
     await initGitRepo(repoDir);
+    process.env.HOME = homeDir;
 
     const userConfigPath = configPaths.getUserConfigPath();
     await fs.mkdir(path.dirname(userConfigPath), { recursive: true });
@@ -189,6 +198,7 @@ describe("cam init", () => {
       "config.json"
     );
     await initGitRepo(repoDir);
+    process.env.HOME = homeDir;
 
     await fs.writeFile(managedConfigPath, "{\n", "utf8");
 

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { configPaths } from "../src/lib/config/load-config.js";
 import {
   initGitRepo,
   writeCamConfig
@@ -158,6 +159,49 @@ describe("cam init", () => {
     );
     expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
       expectedLocalInitConfig
+    );
+  });
+
+  it("does not let an invalid user config outside the target project block init", async () => {
+    const homeDir = await tempDir("cam-init-invalid-user-home-");
+    const repoDir = await tempDir("cam-init-invalid-user-repo-");
+    await initGitRepo(repoDir);
+
+    const userConfigPath = configPaths.getUserConfigPath();
+    await fs.mkdir(path.dirname(userConfigPath), { recursive: true });
+    await fs.writeFile(userConfigPath, "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+  });
+
+  it("does not let an invalid managed config block init", async () => {
+    const homeDir = await tempDir("cam-init-invalid-managed-home-");
+    const repoDir = await tempDir("cam-init-invalid-managed-repo-");
+    const managedConfigPath = path.join(
+      await tempDir("cam-init-invalid-managed-config-"),
+      "config.json"
+    );
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(managedConfigPath, "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init"], {
+      env: {
+        HOME: homeDir,
+        CAM_MANAGED_CONFIG: managedConfigPath
+      }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
     );
   });
 });

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -125,6 +125,25 @@ afterEach(async () => {
 });
 
 describe("integrations command", () => {
+  it("fails closed when integrations install and doctor use empty, whitespace-only, or missing --cwd", async () => {
+    const homeDir = await tempDir("cam-integrations-empty-cwd-home-");
+    const projectDir = await tempDir("cam-integrations-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const command of [
+      ["integrations", "install", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", missingDir]) {
+        const result = runCli(projectDir, [...command, "--cwd", cwd], {
+          env: buildStableCliEnv(homeDir)
+        });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+      }
+    }
+  });
   it("installs the recommended Codex integration stack without creating memory layout", async () => {
     const homeDir = await tempDir("cam-integrations-home-");
     const projectDir = await tempDir("cam-integrations-project-");

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -15,6 +15,10 @@ const originalHome = process.env.HOME;
 const originalCodexHome = process.env.CODEX_HOME;
 const originalPath = process.env.PATH;
 
+function shellQuoteArg(value: string): string {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
 async function tempDir(prefix: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
@@ -148,7 +152,7 @@ describe("integrations command", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
         }
       },
       subactions: {
@@ -340,7 +344,7 @@ describe("integrations command", () => {
       })
     );
     expect(payload.workflowContract.cliFallback.searchCommand).toBe(
-      `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(payload.projectRoot)}`
+      `cam recall search "<query>" --state auto --limit 8 --cwd '${payload.projectRoot}'`
     );
     expect(payload.nextSteps).toEqual(
       expect.arrayContaining([
@@ -465,15 +469,15 @@ describe("integrations command", () => {
     expect(payload.nextSteps).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          `cam mcp apply-guidance --host codex --cwd ${JSON.stringify(payload.projectRoot)}`
+          `cam mcp apply-guidance --host codex --cwd ${shellQuoteArg(payload.projectRoot)}`
         ),
         expect.stringContaining(
-          `cam mcp print-config --host codex --cwd ${JSON.stringify(payload.projectRoot)}`
+          `cam mcp print-config --host codex --cwd ${shellQuoteArg(payload.projectRoot)}`
         )
       ])
     );
     expect(payload.nextSteps[0]).toContain(
-      `cam mcp apply-guidance --host codex --cwd ${JSON.stringify(payload.projectRoot)}`
+      `cam mcp apply-guidance --host codex --cwd ${shellQuoteArg(payload.projectRoot)}`
     );
     expect(payload.nextSteps).not.toEqual(
       expect.arrayContaining([expect.stringContaining("cam hooks install")])
@@ -521,7 +525,7 @@ describe("integrations command", () => {
     expect(payload.nextSteps).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          `cam hooks install --cwd ${JSON.stringify(payload.projectRoot)}`
+          `cam hooks install --cwd ${shellQuoteArg(payload.projectRoot)}`
         )
       ])
     );
@@ -559,7 +563,7 @@ describe("integrations command", () => {
       expect(payload.nextSteps).toEqual(
         expect.arrayContaining([
           expect.stringContaining(
-            `CAM_PROJECT_ROOT=${JSON.stringify(payload.projectRoot)}`
+            `CAM_PROJECT_ROOT=${shellQuoteArg(payload.projectRoot)}`
           ),
           expect.stringContaining("memory-recall.sh")
         ])
@@ -1515,7 +1519,7 @@ describe("integrations command", () => {
       failureMessage: expect.stringContaining("broken codex config"),
       rollbackApplied: true,
       subactions: {
-        mcp: { attempted: false },
+        mcp: { attempted: true, status: "blocked", action: "blocked" },
         agents: { attempted: false },
         hooks: { attempted: false },
         skills: { attempted: false }
@@ -1616,6 +1620,11 @@ describe("integrations command", () => {
     process.env.HOME = homeDir;
 
     await fs.mkdir(path.join(realProjectDir, ".codex", "config.toml"), { recursive: true });
+    await fs.writeFile(
+      path.join(realProjectDir, ".codex", "config.toml", "keep.txt"),
+      "do-not-delete",
+      "utf8"
+    );
 
     const { runIntegrationsApply } = await import("../src/lib/commands/integrations.js");
     const payload = JSON.parse(
@@ -1643,12 +1652,15 @@ describe("integrations command", () => {
       failureMessage: expect.stringContaining("directory"),
       rollbackApplied: true,
       subactions: {
-        mcp: { attempted: false },
+        mcp: { attempted: true, status: "blocked", action: "blocked" },
         agents: { attempted: false },
         hooks: { attempted: false },
         skills: { attempted: false }
       }
     });
+    expect(
+      await fs.readFile(path.join(realProjectDir, ".codex", "config.toml", "keep.txt"), "utf8")
+    ).toBe("do-not-delete");
   });
 
   it("withholds integrations apply from doctor next steps when AGENTS guidance is unsafe", async () => {
@@ -1736,7 +1748,7 @@ describe("integrations command", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
         }
       },
       subactions: {

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -125,7 +125,7 @@ afterEach(async () => {
 });
 
 describe("integrations command", () => {
-  it("fails closed when integrations install and doctor use empty, whitespace-only, or missing --cwd", async () => {
+  it("fails closed when integrations install, apply, and doctor use empty, whitespace-only, or missing --cwd", async () => {
     const homeDir = await tempDir("cam-integrations-empty-cwd-home-");
     const projectDir = await tempDir("cam-integrations-empty-cwd-project-");
     process.env.HOME = homeDir;
@@ -133,6 +133,7 @@ describe("integrations command", () => {
 
     for (const command of [
       ["integrations", "install", "--host", "codex"] as const,
+      ["integrations", "apply", "--host", "codex"] as const,
       ["integrations", "doctor", "--host", "codex"] as const
     ]) {
       for (const cwd of ["", "   ", missingDir]) {

--- a/test/mcp-command.test.ts
+++ b/test/mcp-command.test.ts
@@ -686,7 +686,7 @@ describe("mcp command", () => {
         progressiveDisclosure: "Use progressive disclosure: search -> timeline -> details."
       },
       cliFallback: {
-        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`
+        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`
       }
     });
     expect(payload.agentsGuidance).toMatchObject({
@@ -1617,14 +1617,14 @@ describe("mcp command", () => {
       recallFirst: expect.stringContaining("recall durable memory first"),
       progressiveDisclosure: "Use progressive disclosure: search -> timeline -> details.",
       cliFallback: {
-        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`,
-        timelineCommand: `cam recall timeline "<ref>" --cwd ${JSON.stringify(realProjectDir)}`,
-        detailsCommand: `cam recall details "<ref>" --cwd ${JSON.stringify(realProjectDir)}`
+        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`,
+        timelineCommand: `cam recall timeline "<ref>" --cwd '${realProjectDir}'`,
+        detailsCommand: `cam recall details "<ref>" --cwd '${realProjectDir}'`
       },
       postWorkSyncReview: {
         helperScript: "post-work-memory-review.sh",
-        syncCommand: `cam sync --cwd ${JSON.stringify(realProjectDir)}`,
-        reviewCommand: `cam memory --recent --cwd ${JSON.stringify(realProjectDir)}`
+        syncCommand: `cam sync --cwd '${realProjectDir}'`,
+        reviewCommand: `cam memory --recent --cwd '${realProjectDir}'`
       }
     });
     expect(payload.codexStack).toMatchObject({
@@ -1662,7 +1662,7 @@ describe("mcp command", () => {
       status: "warning",
       summary: expect.stringContaining("Markdown"),
       repairCommand: expect.stringContaining(
-        `memory reindex --scope all --state all --cwd ${JSON.stringify(realProjectDir)}`
+        `memory reindex --scope all --state all --cwd '${realProjectDir}'`
       ),
       checks: expect.arrayContaining([
         expect.objectContaining({
@@ -2981,15 +2981,15 @@ describe("mcp command", () => {
         }
       },
       cliFallback: {
-        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realProjectDir)}`,
-        timelineCommand: `cam recall timeline "<ref>" --cwd ${JSON.stringify(realProjectDir)}`,
-        detailsCommand: `cam recall details "<ref>" --cwd ${JSON.stringify(realProjectDir)}`,
+        searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realProjectDir}'`,
+        timelineCommand: `cam recall timeline "<ref>" --cwd '${realProjectDir}'`,
+        detailsCommand: `cam recall details "<ref>" --cwd '${realProjectDir}'`,
         requiresCamOnPath: true
       },
       postWorkSyncReview: {
         helperScript: "post-work-memory-review.sh",
-        syncCommand: `cam sync --cwd ${JSON.stringify(realProjectDir)}`,
-        reviewCommand: `cam memory --recent --cwd ${JSON.stringify(realProjectDir)}`,
+        syncCommand: `cam sync --cwd '${realProjectDir}'`,
+        reviewCommand: `cam memory --recent --cwd '${realProjectDir}'`,
         shellOnly: true,
         requiresCamOnPath: true
       }

--- a/test/mcp-command.test.ts
+++ b/test/mcp-command.test.ts
@@ -700,6 +700,23 @@ describe("mcp command", () => {
     );
   });
 
+  it("fails closed when print-config --cwd is an empty string", async () => {
+    const homeDir = await tempDir("cam-mcp-empty-cwd-home-");
+    const projectDir = await tempDir("cam-mcp-empty-cwd-project-");
+    process.env.HOME = homeDir;
+
+    const result = runCli(
+      projectDir,
+      ["mcp", "print-config", "--host", "codex", "--cwd", "", "--json"],
+      {
+        env: { HOME: homeDir }
+      }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory");
+  });
+
   it("applies the recommended AGENTS guidance by creating a managed block when AGENTS.md is missing", async () => {
     const homeDir = await tempDir("cam-mcp-apply-guidance-create-home-");
     const projectDir = await tempDir("cam-mcp-apply-guidance-create-project-");

--- a/test/memory-command.test.ts
+++ b/test/memory-command.test.ts
@@ -34,6 +34,43 @@ async function readFileIfExists(filePath: string): Promise<string | null> {
   }
 }
 
+async function pathExists(pathname: string): Promise<boolean> {
+  try {
+    await fs.access(pathname);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pathContainsCam(dir: string): Promise<boolean> {
+  const candidates =
+    process.platform === "win32"
+      ? [path.join(dir, "cam.cmd"), path.join(dir, "cam.exe")]
+      : [path.join(dir, "cam")];
+
+  for (const candidate of candidates) {
+    if (await pathExists(candidate)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function buildPathWithoutCam(extraDir: string): Promise<string> {
+  const baseEntries = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const filteredEntries: string[] = [];
+
+  for (const entry of baseEntries) {
+    if (!(await pathContainsCam(entry))) {
+      filteredEntries.push(entry);
+    }
+  }
+
+  return [extraDir, ...filteredEntries].join(path.delimiter);
+}
+
 async function snapshotFiles(filePaths: string[]): Promise<Record<string, string | null>> {
   return Object.fromEntries(
     await Promise.all(
@@ -2803,6 +2840,62 @@ describe("runMemory", () => {
     expect(result.stdout).toContain("Details are unavailable for deleted refs");
     expect(result.stdout).toContain("memory --recent");
     expect(result.stdout).toContain("memory reindex");
+  });
+
+  it("keeps delete-only forget follow-up commands aligned with the resolved launcher and pinned cwd", async () => {
+    const homeDir = await tempDir("cam-forget-delete-only-home-");
+    const projectDir = await tempDir("cam-forget-delete-only-project-");
+    const callerDir = await tempDir("cam-forget-delete-only-caller-");
+    const memoryRoot = await tempDir("cam-forget-delete-only-root-");
+    const emptyPathDir = await tempDir("cam-forget-delete-only-empty-path-");
+    const fakeDistDir = await tempDir("cam-forget-delete-only-dist-");
+    const fakeDistCliPath = path.join(fakeDistDir, "cli.js");
+    const realProjectDir = await fs.realpath(projectDir);
+    process.env.HOME = homeDir;
+
+    await fs.writeFile(
+      fakeDistCliPath,
+      "#!/usr/bin/env node\nconsole.log('fake dist cli');\n",
+      "utf8"
+    );
+
+    const projectConfig = buildProjectConfig();
+    await writeProjectConfig(projectDir, projectConfig, {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const project = detectProjectContext(projectDir);
+    const store = new MemoryStore(project, {
+      ...projectConfig,
+      autoMemoryDirectory: memoryRoot
+    });
+    await store.ensureLayout();
+    await store.remember(
+      "project",
+      "workflow",
+      "prefer-pnpm",
+      "Prefer pnpm in this repository.",
+      ["Use pnpm instead of npm in this repository."],
+      "Manual note."
+    );
+
+    const result = runCli(
+      callerDir,
+      ["forget", "pnpm", "--scope", "project", "--cwd", projectDir],
+      {
+        env: {
+          HOME: homeDir,
+          PATH: await buildPathWithoutCam(emptyPathDir),
+          CODEX_AUTO_MEMORY_DIST_CLI_PATH: fakeDistCliPath
+        }
+      }
+    );
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      `node ${JSON.stringify(fakeDistCliPath)} recall timeline "project:active:workflow:prefer-pnpm" --cwd '${realProjectDir}'`
+    );
+    expect(result.stdout).toContain("node ");
+    expect(result.stdout).not.toContain("use cam recall timeline to review the deletion trail");
   });
 
   it("surfaces an additive empty reviewer payload for forget --json when nothing matches", async () => {

--- a/test/memory-command.test.ts
+++ b/test/memory-command.test.ts
@@ -4153,4 +4153,57 @@ describe("runMemory", () => {
     expect(result.stdout).toContain("Rebuild retrieval sidecars from canonical Markdown memory");
     expect(result.stdout).not.toContain("--enable");
   });
+
+  it("lets memory reindex subcommand options override parent memory options", async () => {
+    const homeDir = await tempDir("cam-memory-reindex-parent-child-home-");
+    const projectDir = await tempDir("cam-memory-reindex-parent-child-project-");
+    const memoryRoot = await tempDir("cam-memory-reindex-parent-child-root-");
+    process.env.HOME = homeDir;
+
+    const projectConfig = buildProjectConfig();
+    await writeProjectConfig(projectDir, projectConfig, {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const store = new MemoryStore(detectProjectContext(projectDir), {
+      ...projectConfig,
+      autoMemoryDirectory: memoryRoot
+    });
+    await store.ensureLayout();
+    await store.remember(
+      "project",
+      "workflow",
+      "prefer-pnpm",
+      "Prefer pnpm in this repository.",
+      ["Use pnpm instead of npm in this repository."],
+      "Manual note."
+    );
+
+    const result = runCli(
+      projectDir,
+      [
+        "memory",
+        "--scope",
+        "project-local",
+        "reindex",
+        "--scope",
+        "project",
+        "--state",
+        "active",
+        "--json"
+      ],
+      { env: { HOME: homeDir } }
+    );
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      requestedScope: "project",
+      requestedState: "active",
+      rebuilt: [
+        expect.objectContaining({
+          scope: "project",
+          state: "active"
+        })
+      ]
+    });
+  });
 });

--- a/test/recovery-records.test.ts
+++ b/test/recovery-records.test.ts
@@ -209,6 +209,6 @@ describe("recovery-records", () => {
         sourceSessionId: "session-1",
         scope: "project"
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/test/retrieval-contract.test.ts
+++ b/test/retrieval-contract.test.ts
@@ -5,7 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   appendCliCwdFlag,
   buildResolvedCliCommand,
-  buildWorkflowContract
+  buildWorkflowContract,
+  resolveCliLauncher
 } from "../src/lib/integration/retrieval-contract.js";
 
 const tempDirs: string[] = [];
@@ -65,5 +66,26 @@ describe("retrieval contract", () => {
       resolvedCommand: `node ${JSON.stringify(fakeDistCliPath)}`
     });
     expect(buildResolvedCliCommand("mcp doctor --host codex")).toContain(fakeDistCliPath);
+  });
+
+  it("keeps resolved CLI fallback commands aligned with an explicit launcher override", () => {
+    const launcher = resolveCliLauncher({
+      pathValue: "",
+      distCliPath: "/tmp/custom-dist/cli.js",
+      distCliPathExists: true
+    });
+
+    const workflowContract = buildWorkflowContract({
+      cwd: "/tmp/project",
+      launcherOverride: launcher
+    });
+
+    expect(workflowContract.launcher).toMatchObject({
+      resolution: "node-dist",
+      resolvedCommand: 'node "/tmp/custom-dist/cli.js"'
+    });
+    expect(workflowContract.resolvedCliFallback.searchCommand).toContain("/tmp/custom-dist/cli.js");
+    expect(workflowContract.resolvedCliFallback.timelineCommand).toContain("/tmp/custom-dist/cli.js");
+    expect(workflowContract.resolvedCliFallback.detailsCommand).toContain("/tmp/custom-dist/cli.js");
   });
 });

--- a/test/retrieval-contract.test.ts
+++ b/test/retrieval-contract.test.ts
@@ -37,13 +37,13 @@ afterEach(async () => {
 describe("retrieval contract", () => {
   it("shell-quotes cwd values so the shell cannot expand them", () => {
     expect(appendCliCwdFlag("cam recall search \"<query>\"", "/tmp/$HOME/path with spaces")).toBe(
-      "cam recall search \"<query>\" --cwd \"/tmp/$HOME/path with spaces\""
+      "cam recall search \"<query>\" --cwd '/tmp/$HOME/path with spaces'"
     );
   });
 
   it("escapes embedded single quotes in cwd values", () => {
     expect(appendCliCwdFlag("cam recall details \"<ref>\"", "/tmp/it's-safe")).toBe(
-      "cam recall details \"<ref>\" --cwd \"/tmp/it's-safe\""
+      "cam recall details \"<ref>\" --cwd '/tmp/it'\"'\"'s-safe'"
     );
   });
 

--- a/test/session-command.test.ts
+++ b/test/session-command.test.ts
@@ -57,6 +57,15 @@ process.exit(0);
   return mockCodexPath;
 }
 
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("runSession", () => {
   it("shows an empty compact prior preview when no continuity audit history exists", async () => {
     const repoDir = await tempDir("cam-session-empty-history-repo-");
@@ -574,6 +583,65 @@ describe("runSession", () => {
     expect(statusPayload.startup.continuitySectionKinds).toContain("sources");
     expect(statusPayload.projectLocation.exists).toBe(true);
     expect(statusPayload.localLocation.exists).toBe(false);
+  }, 30_000);
+
+  it("keeps session load and status read-only on an uninitialized project", async () => {
+    const homeDir = await tempDir("cam-session-readonly-home-");
+    const projectDir = await tempDir("cam-session-readonly-project-");
+    const memoryRootParent = await tempDir("cam-session-readonly-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+    await initRepo(projectDir);
+
+    await writeProjectConfig(
+      projectDir,
+      configJson(),
+      { autoMemoryDirectory: memoryRoot }
+    );
+
+    const statusResult = runCli(projectDir, ["session", "status", "--json"], {
+      env: { HOME: homeDir }
+    });
+    const loadResult = runCli(projectDir, ["session", "load", "--json", "--print-startup"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(statusResult.exitCode, statusResult.stderr).toBe(0);
+    expect(loadResult.exitCode, loadResult.stderr).toBe(0);
+    expect(JSON.parse(statusResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(JSON.parse(loadResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(await pathExists(memoryRoot)).toBe(false);
   }, 30_000);
 
   it("refresh replaces only the selected scope", async () => {

--- a/test/session-command.test.ts
+++ b/test/session-command.test.ts
@@ -1087,6 +1087,71 @@ describe("runSession", () => {
     expect(payload.latestContinuityAuditEntry?.writeMode).toBe("merge");
   }, 30_000);
 
+  it("save still prefers the latest primary rollout over older matching audit provenance", async () => {
+    const repoDir = await tempDir("cam-session-save-primary-preferred-repo-");
+    const memoryRoot = await tempDir("cam-session-save-primary-preferred-memory-");
+    const sessionsDir = await tempDir("cam-session-save-primary-preferred-sessions-");
+    const dayDir = path.join(sessionsDir, "2026", "03", "15");
+    process.env.CAM_CODEX_SESSIONS_DIR = sessionsDir;
+    await fs.mkdir(dayDir, { recursive: true });
+    await initRepo(repoDir);
+
+    await writeProjectConfig(repoDir, configJson(), {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const auditRolloutPath = path.join(repoDir, "older-matching-audit-rollout.jsonl");
+    await fs.writeFile(
+      auditRolloutPath,
+      rolloutFixture(repoDir, "Old audit provenance should not win normal save.", {
+        sessionId: "session-older-audit"
+      }),
+      "utf8"
+    );
+    const primaryRolloutPath = path.join(dayDir, "rollout-primary.jsonl");
+    await fs.writeFile(
+      primaryRolloutPath,
+      rolloutFixture(repoDir, "Newest primary rollout should drive normal save.", {
+        sessionId: "session-new-primary"
+      }),
+      "utf8"
+    );
+
+    const project = detectProjectContext(repoDir);
+    const store = new SessionContinuityStore(project, {
+      ...configJson(),
+      autoMemoryDirectory: memoryRoot
+    });
+    await store.appendAuditLog({
+      generatedAt: "2026-03-18T00:01:00.000Z",
+      projectId: project.projectId,
+      worktreeId: project.worktreeId,
+      configuredExtractorMode: "heuristic",
+      trigger: "manual-save",
+      writeMode: "merge",
+      scope: "both",
+      rolloutPath: auditRolloutPath,
+      sourceSessionId: "session-older-audit",
+      preferredPath: "heuristic",
+      actualPath: "heuristic",
+      fallbackReason: "configured-heuristic",
+      evidenceCounts: makeEvidenceCounts(),
+      writtenPaths: ["/tmp/continuity-audit.md"]
+    });
+
+    const payload = JSON.parse(
+      await runSession("save", { cwd: repoDir, scope: "project-local", json: true })
+    ) as {
+      rolloutPath: string;
+      rolloutSelection: { kind: string; rolloutPath: string };
+    };
+    expect(payload.rolloutSelection).toEqual({
+      kind: "latest-primary-rollout",
+      rolloutPath: primaryRolloutPath
+    });
+    expect(payload.rolloutPath).toBe(primaryRolloutPath);
+  }, 30_000);
+
   it("save prefers a matching recovery marker over a newer primary rollout", async () => {
     const repoDir = await tempDir("cam-session-save-recovery-priority-repo-");
     const memoryRoot = await tempDir("cam-session-save-recovery-priority-memory-");
@@ -1157,6 +1222,59 @@ describe("runSession", () => {
 
     const merged = await store.readMergedState();
     expect(merged?.goal).toContain("Retry the recovery provenance for save.");
+    expect(await store.readRecoveryRecord()).toBeNull();
+  }, 30_000);
+
+  it("clears a scope=both recovery marker after a single-scope save reuses it", async () => {
+    const repoDir = await tempDir("cam-session-save-clear-shared-recovery-repo-");
+    const memoryRoot = await tempDir("cam-session-save-clear-shared-recovery-memory-");
+    await initRepo(repoDir);
+
+    await writeProjectConfig(repoDir, configJson(), {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const recoveryRolloutPath = path.join(repoDir, "shared-recovery-rollout.jsonl");
+    await fs.writeFile(
+      recoveryRolloutPath,
+      rolloutFixture(repoDir, "Single-scope save should clear the shared recovery marker.", {
+        sessionId: "session-shared-recovery"
+      }),
+      "utf8"
+    );
+
+    const project = detectProjectContext(repoDir);
+    const store = new SessionContinuityStore(project, {
+      ...configJson(),
+      autoMemoryDirectory: memoryRoot
+    });
+    await store.writeRecoveryRecord({
+      recordedAt: "2026-03-18T00:00:00.000Z",
+      projectId: project.projectId,
+      worktreeId: project.worktreeId,
+      rolloutPath: recoveryRolloutPath,
+      sourceSessionId: "session-shared-recovery",
+      trigger: "manual-save",
+      writeMode: "merge",
+      scope: "both",
+      writtenPaths: [store.paths.sharedFile, store.paths.localFile],
+      preferredPath: "heuristic",
+      actualPath: "heuristic",
+      fallbackReason: "configured-heuristic",
+      evidenceCounts: makeEvidenceCounts(),
+      failedStage: "audit-write",
+      failureMessage: "retry the same save provenance"
+    });
+
+    const payload = JSON.parse(
+      await runSession("save", { cwd: repoDir, scope: "project-local", json: true })
+    ) as {
+      rolloutSelection: { kind: string; rolloutPath: string };
+    };
+    expect(payload.rolloutSelection).toEqual({
+      kind: "pending-recovery-marker",
+      rolloutPath: recoveryRolloutPath
+    });
     expect(await store.readRecoveryRecord()).toBeNull();
   }, 30_000);
 

--- a/test/skills-command.test.ts
+++ b/test/skills-command.test.ts
@@ -98,7 +98,7 @@ describe("skills command", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(await fs.realpath(projectDir))}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${await fs.realpath(projectDir)}'`
         },
         postWorkSyncReview: {
           helperScript: "post-work-memory-review.sh"
@@ -201,8 +201,8 @@ describe("skills command", () => {
     const skillFile = await fs.readFile(officialSkillPath, "utf8");
     expect(skillFile).toContain("cam:asset-version");
     expect(skillFile).toContain("timeline_memories");
-    expect(skillFile).toContain(`--cwd ${JSON.stringify(await fs.realpath(projectDir))}`);
-    expect(skillFile).toContain(` sync --cwd ${JSON.stringify(await fs.realpath(projectDir))}`);
+    expect(skillFile).toContain(`--cwd '${await fs.realpath(projectDir)}'`);
+    expect(skillFile).toContain(` sync --cwd '${await fs.realpath(projectDir)}'`);
     expect(skillFile.includes('node "') || skillFile.includes("cam sync")).toBe(true);
 
     await expect(

--- a/test/skills-command.test.ts
+++ b/test/skills-command.test.ts
@@ -31,6 +31,21 @@ afterEach(async () => {
 });
 
 describe("skills command", () => {
+  it("fails closed when --cwd is empty, whitespace-only, or missing", async () => {
+    const homeDir = await tempDir("cam-skills-empty-cwd-home-");
+    const projectDir = await tempDir("cam-skills-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const cwd of ["", "   ", missingDir]) {
+      const result = runCli(projectDir, ["skills", "install", "--cwd", cwd], {
+        env: { HOME: homeDir }
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
   it("installs a Codex skill for progressive durable memory retrieval", async () => {
     const homeDir = await tempDir("cam-skills-home-");
     const projectDir = await tempDir("cam-skills-project-");

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -924,17 +924,22 @@ describe("tarball install smoke", () => {
       }
     });
 
-    for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
-      const invalidDoctorResult = runCommandCapture(
-        camBinaryPath(installDir),
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        blockedProjectDir,
-        envWithBin
-      );
-      expect(invalidDoctorResult.exitCode).toBe(1);
-      expect(invalidDoctorResult.stderr).toContain(
-        "--cwd must be a non-empty path to an existing directory."
-      );
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
+        const invalidResult = runCommandCapture(
+          camBinaryPath(installDir),
+          [...command, "--cwd", cwd],
+          blockedProjectDir,
+          envWithBin
+        );
+        expect(invalidResult.exitCode).toBe(1);
+        expect(invalidResult.stderr).toContain(
+          "--cwd must be a non-empty path to an existing directory."
+        );
+      }
     }
 
     const recallHelpResult = runCommandCapture(

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -924,6 +924,19 @@ describe("tarball install smoke", () => {
       }
     });
 
+    for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
+      const invalidDoctorResult = runCommandCapture(
+        camBinaryPath(installDir),
+        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
+        blockedProjectDir,
+        envWithBin
+      );
+      expect(invalidDoctorResult.exitCode).toBe(1);
+      expect(invalidDoctorResult.stderr).toContain(
+        "--cwd must be a non-empty path to an existing directory."
+      );
+    }
+
     const recallHelpResult = runCommandCapture(
       camBinaryPath(installDir),
       ["recall", "search", "--help"],

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -330,7 +330,7 @@ describe("tarball install smoke", () => {
           preferredRoute: "mcp-first"
         },
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realInstallDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realInstallDir}'`
         }
       },
       agentsGuidance: {
@@ -563,7 +563,7 @@ describe("tarball install smoke", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realInstallDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realInstallDir}'`
         }
       },
       subactions: {
@@ -588,7 +588,7 @@ describe("tarball install smoke", () => {
       workflowContract: {
         recommendedPreset: "state=auto, limit=8",
         cliFallback: {
-          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd ${JSON.stringify(realInstallDir)}`
+          searchCommand: `cam recall search "<query>" --state auto --limit 8 --cwd '${realInstallDir}'`
         }
       },
       subactions: {
@@ -900,7 +900,7 @@ describe("tarball install smoke", () => {
       failureMessage: expect.stringContaining("directory"),
       rollbackApplied: true,
       subactions: {
-        mcp: { attempted: false },
+        mcp: { attempted: true, status: "blocked", action: "blocked" },
         agents: { attempted: false },
         hooks: { attempted: false },
         skills: { attempted: false }

--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -6,6 +6,7 @@ describe("vitest config", () => {
   it("excludes project-local worktree directories from test discovery", async () => {
     const configSource = await fs.readFile(path.resolve("vitest.config.ts"), "utf8");
 
+    expect(configSource).toContain("configDefaults.exclude");
     expect(configSource).toContain("**/.worktrees/**");
     expect(configSource).toContain("**/worktrees/**");
   });

--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("vitest config", () => {
+  it("excludes project-local worktree directories from test discovery", async () => {
+    const configSource = await fs.readFile(path.resolve("vitest.config.ts"), "utf8");
+
+    expect(configSource).toContain("**/.worktrees/**");
+    expect(configSource).toContain("**/worktrees/**");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    exclude: ["**/.worktrees/**", "**/worktrees/**"],
     fileParallelism: false,
     hookTimeout: 30_000,
     testTimeout: 30_000

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["**/.worktrees/**", "**/worktrees/**"],
+    exclude: [...configDefaults.exclude, "**/.worktrees/**", "**/worktrees/**"],
     fileParallelism: false,
     hookTimeout: 30_000,
     testTimeout: 30_000


### PR DESCRIPTION
## Summary

- follows PR #17 with a narrow docs/contract wave for Claude Code and Gemini CLI host integration boundaries
- adds a dedicated host-boundary note that separates publicly documented Claude/Gemini host surfaces from the manual-only integration surface this repository currently supports
- tightens the existing host strategy, integration strategy, docs hubs, README entry points, and repository AGENTS notes so the Codex-only mutable boundary stays easy to review

## Included

- new `docs/host-integration-claude-gemini.md` guidance for current host reality
- boundary tightening in `docs/host-surfaces.md` and `docs/integration-strategy.md`
- docs navigation updates in `README.md`, `README.en.md`, `docs/README.md`, and `docs/README.en.md`
- additive repository note update in root `AGENTS.md`

## Excluded

- no new mutable `claude` / `gemini` install or apply surface
- no route-truth, durable-memory, continuity, or retrieval semantic changes
- no host-native hooks / skills / extensions auto-installation for Claude or Gemini

## Verification

- `pnpm lint`
- `pnpm test:docs-contract`

## Stack Notes

- branch: `pr/issue5-12-claude-gemini-host-boundaries`
- base: `pr/issue5-11-help-and-boundary-closure`
- head commit: `7eef3d0`
- backup refs created before implementation:
  - `backup/2026-04-10-pr12-start-pr11-20260410-203547`
  - matching `backup-tag/...`



## Review Order

- Active issue5 review stack position: 5 of 5
- Review this last, after #17.
- Older bridge drafts #12 and #13 remain draft and are not part of the primary reviewer path for this wave.
- Current remote head for this PR: `7eef3d0`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Claude Code and Gemini CLI host boundaries and keeps them manual-only via `cam mcp print-config` and `cam mcp doctor`. Also hardens CLI/runtime contracts: safer `--cwd` handling, idempotent `cam init --force`, read-only session inspection, and stable retrieval/launcher behavior.

- New Features
  - Added `docs/host-integration-claude-gemini.md`; linked from READMEs and host docs; restates that Claude/Gemini remain manual-only.
  - `cam init` now supports `--force`, validates/retains existing configs when safe, and stays idempotent.
  - Retrieval workflow and guidance now shell-quote `--cwd` and respect the resolved or overridden launcher; memory reindex subcommand options override parent options.

- Bug Fixes
  - All entrypoints fail-closed on empty/invalid `--cwd` (`mcp`, `integrations`, `hooks`, `skills`, and compiled CLI).
  - `cam session status/load` are read-only and do not create memory layout.
  - Issue-tracker keys include non-generic host context to avoid collisions across hosts or same numeric IDs.
  - Hardened integrations apply reporting/rollback and asset quoting; test config now excludes worktree dirs.

<sup>Written for commit 961945f3901757e7c733f94700b9d237c53ff364. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

