### PR TITLE
fix: keep session inspection read-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,11 @@ cam session status
 当前优先事项：
 
 1. 继续保持 issue5 stack 的 reviewer contract、help surface、release-facing smoke 一致
-2. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
-3. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
-4. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
-5. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
+2. 收紧 issue-tracker durable memory replacement key，避免不同 host 的 tracker URL 因相同 repo/path 或 ticket id 被误判为同一条 memory
+3. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
+4. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
+5. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
+6. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
 
 下一阶段建议：
 
@@ -106,6 +107,7 @@ cam session status
 
 ## 变更记录
 
+- 2026-04-11: issue5 tail closeout 新增 cross-host issue-tracker 回归保护：`directive-utils` 现在用完整的 non-generic hostname 片段构造 issue-tracker resource key，避免不同 host 但相同 repo/path 或 ticket id 的 URL 互相覆盖；同时补强 `vitest.config.ts` 的默认 exclude contract 测试，并把 `integrations apply --cwd` 的 invalid-path fail-closed 行为纳入 source / dist / tarball 回归覆盖。
 - 2026-04-10: issue5 PR14 收口了三类 runtime contract seam：`mcp` 命令的空 `--cwd` 现在 fail-closed；`workflowContract` 的 resolved launcher 与显式 `launcherOverride` 保持一致；delete-only 的 forget follow-up 文案不再硬编码裸 `cam recall timeline`。
 - 2026-04-10: `test/recovery-records.test.ts` 已对齐当前 continuity 语义：`scope=both` continuity recovery marker 可以被后续 single-scope save/refresh 复用，并继续由 `session-command` 行为测试锁定。
 - 2026-04-10: 新增根级 `AGENTS.md`，补齐仓库级功能说明、命令面、关键 JSON 契约与项目规划。

--- a/src/lib/cli/register-commands.ts
+++ b/src/lib/cli/register-commands.ts
@@ -308,7 +308,8 @@ export function registerCommands(program: Command): void {
   program
     .command("init")
     .description("Initialize Codex Auto Memory in the current project")
-    .action(withStdout(async () => runInit()));
+    .option("--force", "Overwrite existing init config files with canonical defaults")
+    .action(withStdout(async (options) => runInit(options)));
 
   const memoryCommand = program
     .command("memory")

--- a/src/lib/commands/init.ts
+++ b/src/lib/commands/init.ts
@@ -1,13 +1,41 @@
 import { configPaths } from "../config/load-config.js";
+import { rawProjectConfigSchema } from "../config/schema.js";
 import { MemoryStore } from "../domain/memory-store.js";
 import { detectProjectContext, getDefaultMemoryDirectory } from "../domain/project-context.js";
 import { SessionContinuityStore } from "../domain/session-continuity-store.js";
-import { updateGitignoreLine, writeJsonFile } from "../util/fs.js";
+import { buildRuntimeContext } from "../runtime/runtime-context.js";
+import { fileExists, readJsonFile, updateGitignoreLine, writeJsonFile } from "../util/fs.js";
 import type { AppConfig } from "../types.js";
 
 interface InitOptions {
   cwd?: string;
   force?: boolean;
+}
+
+async function ensureInitConfigShape(
+  filePath: string,
+  label: "project" | "local"
+): Promise<void> {
+  if (!(await fileExists(filePath))) {
+    return;
+  }
+
+  let raw: unknown;
+  try {
+    raw = await readJsonFile<unknown>(filePath);
+  } catch {
+    throw new Error(
+      `Existing ${label} config at ${filePath} is invalid. Re-run with --force to overwrite it.`
+    );
+  }
+
+  try {
+    rawProjectConfigSchema.parse(raw);
+  } catch {
+    throw new Error(
+      `Existing ${label} config at ${filePath} is invalid. Re-run with --force to overwrite it.`
+    );
+  }
 }
 
 export async function runInit(options: InitOptions = {}): Promise<string> {
@@ -26,18 +54,29 @@ export async function runInit(options: InitOptions = {}): Promise<string> {
     codexBinary: "codex"
   };
 
-  await writeJsonFile(projectConfigPath, projectConfig);
-  await writeJsonFile(localConfigPath, {
-    autoMemoryEnabled: true
-  });
+  if (!options.force) {
+    await ensureInitConfigShape(projectConfigPath, "project");
+    await ensureInitConfigShape(localConfigPath, "local");
+  }
+
+  if (options.force || !(await fileExists(projectConfigPath))) {
+    await writeJsonFile(projectConfigPath, projectConfig);
+  }
+  if (options.force || !(await fileExists(localConfigPath))) {
+    await writeJsonFile(localConfigPath, {
+      autoMemoryEnabled: true
+    });
+  }
   await updateGitignoreLine(project.projectRoot, ".codex-auto-memory.local.json");
 
-  const config: AppConfig = {
-    ...projectConfig,
-    autoMemoryDirectory: getDefaultMemoryDirectory()
-  };
+  const runtime = await buildRuntimeContext(project.projectRoot);
+  const config: AppConfig = runtime.loadedConfig.config.autoMemoryDirectory
+    ? runtime.loadedConfig.config
+    : {
+        ...runtime.loadedConfig.config,
+        autoMemoryDirectory: getDefaultMemoryDirectory()
+      };
   const store = new MemoryStore(project, config);
-  await store.ensureLayout();
   const continuityStore = new SessionContinuityStore(project, config);
   const excludePath = await continuityStore.ensureLocalIgnore();
 

--- a/src/lib/commands/init.ts
+++ b/src/lib/commands/init.ts
@@ -3,8 +3,8 @@ import { rawProjectConfigSchema } from "../config/schema.js";
 import { MemoryStore } from "../domain/memory-store.js";
 import { detectProjectContext, getDefaultMemoryDirectory } from "../domain/project-context.js";
 import { SessionContinuityStore } from "../domain/session-continuity-store.js";
-import { buildRuntimeContext } from "../runtime/runtime-context.js";
 import { fileExists, readJsonFile, updateGitignoreLine, writeJsonFile } from "../util/fs.js";
+import { resolveAppPath } from "../util/paths.js";
 import type { AppConfig } from "../types.js";
 
 interface InitOptions {
@@ -69,13 +69,20 @@ export async function runInit(options: InitOptions = {}): Promise<string> {
   }
   await updateGitignoreLine(project.projectRoot, ".codex-auto-memory.local.json");
 
-  const runtime = await buildRuntimeContext(project.projectRoot);
-  const config: AppConfig = runtime.loadedConfig.config.autoMemoryDirectory
-    ? runtime.loadedConfig.config
-    : {
-        ...runtime.loadedConfig.config,
-        autoMemoryDirectory: getDefaultMemoryDirectory()
-      };
+  const persistedProjectConfig = rawProjectConfigSchema.parse(
+    (await readJsonFile(projectConfigPath)) ?? projectConfig
+  );
+  const persistedLocalConfig = rawProjectConfigSchema.parse(
+    (await readJsonFile(localConfigPath)) ?? { autoMemoryEnabled: true }
+  );
+  const config: AppConfig = {
+    ...projectConfig,
+    ...persistedProjectConfig,
+    ...persistedLocalConfig,
+    autoMemoryDirectory: persistedLocalConfig.autoMemoryDirectory
+      ? resolveAppPath(persistedLocalConfig.autoMemoryDirectory)
+      : getDefaultMemoryDirectory()
+  };
   const store = new MemoryStore(project, config);
   const continuityStore = new SessionContinuityStore(project, config);
   const excludePath = await continuityStore.ensureLocalIgnore();

--- a/src/lib/commands/session.ts
+++ b/src/lib/commands/session.ts
@@ -170,10 +170,10 @@ export async function runSession(
   options: SessionOptions = {}
 ): Promise<string> {
   const cwd = options.cwd ?? process.cwd();
-  const runtime = await buildRuntimeContext(cwd);
   const scope = selectedScope(options.scope);
 
   if (action === "save" || action === "refresh") {
+    const runtime = await buildRuntimeContext(cwd);
     const persistenceRequest = await prepareSessionPersistenceRequest(
       runtime,
       action,
@@ -197,6 +197,7 @@ export async function runSession(
   }
 
   if (action === "clear") {
+    const runtime = await buildRuntimeContext(cwd);
     const cleared = await runtime.sessionContinuityStore.clear(scope);
     if (options.json) {
       return JSON.stringify({ cleared }, null, 2);
@@ -210,6 +211,7 @@ export async function runSession(
   }
 
   if (action === "open") {
+    const runtime = await buildRuntimeContext(cwd);
     await runtime.sessionContinuityStore.ensureLocalLayout();
     openPath(runtime.sessionContinuityStore.paths.localDir);
     return [
@@ -218,6 +220,9 @@ export async function runSession(
     ].join("\n");
   }
 
+  const runtime = await buildRuntimeContext(cwd, {}, {
+    ensureMemoryLayout: false
+  });
   const view = await loadSessionInspectionView(runtime);
 
   if (action === "load") {

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -51,7 +51,8 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
         .map((segment) => slugify(segment))
         .filter(Boolean);
       const hostContextToken =
-        hostTokens.find((token) => !genericHostTokens.has(token)) ?? slugify(parsed.hostname);
+        hostTokens.filter((token) => !genericHostTokens.has(token)).join("-") ||
+        slugify(parsed.hostname);
       const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -35,10 +35,6 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
       .map((segment) => slugify(segment))
       .filter(Boolean);
     const tailToken = [...pathTokens].reverse().find(Boolean);
-    if (tailToken && !genericReferenceTokens.has(tailToken)) {
-      return tailToken;
-    }
-
     if (category === "issue-tracker") {
       const ticketToken =
         [...pathTokens].reverse().find((token) => /^[a-z]+-\d+$/iu.test(token) || /^\d+$/u.test(token)) ??
@@ -59,6 +55,10 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
       const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;
+    }
+
+    if (tailToken && !genericReferenceTokens.has(tailToken)) {
+      return tailToken;
     }
 
     if (tailToken) {

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -30,6 +30,8 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
     const parsed = new URL(url);
     const pathTokens = parsed.pathname
       .split("/")
+      .map((segment) => segment.trim())
+      .filter(Boolean)
       .map((segment) => slugify(segment))
       .filter(Boolean);
     const tailToken = [...pathTokens].reverse().find(Boolean);
@@ -38,6 +40,9 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
     }
 
     if (category === "issue-tracker") {
+      const ticketToken =
+        [...pathTokens].reverse().find((token) => /^[a-z]+-\d+$/iu.test(token) || /^\d+$/u.test(token)) ??
+        null;
       const nonGenericPathTokens = pathTokens.filter((token) => {
         if (genericReferenceTokens.has(token)) {
           return false;
@@ -51,7 +56,7 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
         .filter(Boolean);
       const hostContextToken =
         hostTokens.find((token) => !genericHostTokens.has(token)) ?? slugify(parsed.hostname);
-      const contextToken = nonGenericPathTokens.slice(-2).join("-");
+      const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;
     }

--- a/src/lib/integration/mcp-config.ts
+++ b/src/lib/integration/mcp-config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { detectProjectContext } from "../domain/project-context.js";
 import {
@@ -36,8 +37,28 @@ export interface McpHostConfigSnippet {
 
 export { normalizeMcpHost };
 
+export function resolveMcpProjectCwd(cwd = process.cwd()): string {
+  if (!cwd.trim()) {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  const resolved = path.resolve(cwd);
+  let stat;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  if (!stat.isDirectory()) {
+    throw new Error("--cwd must be a non-empty path to an existing directory.");
+  }
+
+  return resolved;
+}
+
 export function resolveMcpProjectRoot(cwd = process.cwd()): string {
-  return detectProjectContext(path.resolve(cwd)).projectRoot;
+  return detectProjectContext(resolveMcpProjectCwd(cwd)).projectRoot;
 }
 
 export function buildMcpHostConfigSnippet(host: McpHost, projectRoot: string): McpHostConfigSnippet {

--- a/src/lib/integration/mcp-doctor.ts
+++ b/src/lib/integration/mcp-doctor.ts
@@ -51,7 +51,7 @@ import {
 } from "./skills-paths.js";
 import { fileExists, readTextFile } from "../util/fs.js";
 import { buildRuntimeContext } from "../runtime/runtime-context.js";
-import { resolveMcpProjectRoot } from "./mcp-config.js";
+import { resolveMcpProjectCwd, resolveMcpProjectRoot } from "./mcp-config.js";
 import type { RetrievalSidecarCheck } from "../domain/memory-store.js";
 import type { MemoryLayoutDiagnostic, TopicFileDiagnostic } from "../types.js";
 
@@ -1131,7 +1131,9 @@ export async function inspectMcpDoctor(options: {
   host?: string;
   explicitCwd?: boolean;
 } = {}): Promise<McpDoctorReport> {
-  const cwd = await normalizeComparablePath(options.cwd ?? process.cwd());
+  const cwd = await normalizeComparablePath(
+    options.cwd === undefined ? process.cwd() : resolveMcpProjectCwd(options.cwd)
+  );
   const projectRoot = resolveMcpProjectRoot(cwd);
   const agentsGuidancePath = path.join(projectRoot, "AGENTS.md");
   const hostSelection: McpDoctorHostSelection = normalizeMcpDoctorHostSelection(options.host);

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1694,6 +1694,24 @@ describe("dist cli smoke", () => {
     });
   });
 
+  it("fails closed for invalid --cwd on the compiled integrations doctor entrypoint", async () => {
+    const homeDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-home-");
+    const projectDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-project-");
+
+    for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
+      const result = runCli(
+        projectDir,
+        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
+        {
+          entrypoint: "dist",
+          env: { HOME: homeDir }
+        }
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
+
   it("routes exec through the compiled wrapper entrypoint", async () => {
     const repoDir = await tempDir("cam-dist-wrapper-repo-");
     const homeDir = await tempDir("cam-dist-wrapper-home-");

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -55,6 +55,15 @@ async function waitForFile(pathname: string, timeoutMs = 2_000): Promise<string>
   }
 }
 
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 afterEach(async () => {
   if (originalCodexHome === undefined) {
     delete process.env.CODEX_HOME;
@@ -297,6 +306,68 @@ describe("dist cli smoke", () => {
     expect(forgetPayload.followUp.timelineRefs.length).toBeGreaterThan(0);
     expect(forgetPayload.followUp.timelineRefs.length).toBeGreaterThan(0);
   }, 30_000);
+
+  it("keeps session inspection read-only from the compiled cli entrypoint", async () => {
+    const homeDir = await tempDir("cam-dist-session-readonly-home-");
+    const projectDir = await tempDir("cam-dist-session-readonly-project-");
+    const memoryRootParent = await tempDir("cam-dist-session-readonly-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+
+    await writeCamConfig(projectDir, makeAppConfig(), {
+      autoMemoryDirectory: memoryRoot
+    });
+
+    const sessionStatusResult = runCli(projectDir, ["session", "status", "--json"], {
+      entrypoint: "dist",
+      env: { HOME: homeDir }
+    });
+    const sessionLoadResult = runCli(
+      projectDir,
+      ["session", "load", "--json", "--print-startup"],
+      {
+        entrypoint: "dist",
+        env: { HOME: homeDir }
+      }
+    );
+
+    expect(sessionStatusResult.exitCode, sessionStatusResult.stderr).toBe(0);
+    expect(sessionLoadResult.exitCode, sessionLoadResult.stderr).toBe(0);
+    expect(JSON.parse(sessionStatusResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(JSON.parse(sessionLoadResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(await pathExists(memoryRoot)).toBe(false);
+  });
 
   it("uses the recommended recall search preset from the compiled cli entrypoint without creating memory layout on first lookup", async () => {
     const homeDir = await tempDir("cam-dist-recall-home-");

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1694,21 +1694,26 @@ describe("dist cli smoke", () => {
     });
   });
 
-  it("fails closed for invalid --cwd on the compiled integrations doctor entrypoint", async () => {
+  it("fails closed for invalid --cwd on compiled integrations entrypoints", async () => {
     const homeDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-home-");
     const projectDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-project-");
 
-    for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
-      const result = runCli(
-        projectDir,
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        {
-          entrypoint: "dist",
-          env: { HOME: homeDir }
-        }
-      );
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
+        const result = runCli(
+          projectDir,
+          [...command, "--cwd", cwd],
+          {
+            entrypoint: "dist",
+            env: { HOME: homeDir }
+          }
+        );
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+      }
     }
   });
 

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -1282,6 +1282,90 @@ describe("HeuristicExtractor", () => {
     );
   });
 
+  it("does not collapse repo-specific issue URLs that share the same numeric issue id", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "widgets-issues",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://github.com/acme/widgets/issues/123",
+        details: ["Primary widgets issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://github.com/acme/api/issues/123."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "widgets-issues"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://github.com/acme/api/issues/123"
+        })
+      ])
+    );
+  });
+
+  it("does not collapse same-host issue tracker URLs that use distinct ticket ids", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "jira-auth-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://jira.example.com/browse/AUTH-123",
+        details: ["Primary auth issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://jira.example.com/browse/PLAT-456."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "jira-auth-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://jira.example.com/browse/PLAT-456"
+        })
+      ])
+    );
+  });
+
   it("does not suppress different issue tracker URLs when both use a generic browse tail", () => {
     const reviewed = reviewExtractedMemoryOperations(
       [

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -1366,6 +1366,93 @@ describe("HeuristicExtractor", () => {
     );
   });
 
+  it("does not collapse cross-host issue tracker URLs that share the same repo path and ticket id", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "github-foo-widgets-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://github.foo.example.com/acme/widgets/issues/123",
+        details: ["Primary GitHub Enterprise tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: [
+          "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123."
+        ]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "github-foo-widgets-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary:
+            "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123"
+        })
+      ])
+    );
+  });
+
+  it("does not collapse cross-host issue tracker URLs that share the same ticket id behind a generic browse path", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "jira-foo-auth-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://jira.foo.example.com/browse/AUTH-123",
+        details: ["Primary Jira issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://jira.bar.example.com/browse/AUTH-123."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "jira-foo-auth-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://jira.bar.example.com/browse/AUTH-123"
+        })
+      ])
+    );
+  });
+
   it("does not suppress different issue tracker URLs when both use a generic browse tail", () => {
     const reviewed = reviewExtractedMemoryOperations(
       [

--- a/test/hooks-command.test.ts
+++ b/test/hooks-command.test.ts
@@ -48,7 +48,21 @@ afterEach(async () => {
 });
 
 describe("hooks command", () => {
-  it("supports --cwd while keeping generated hook helpers reusable across projects", async () => {
+  it("fails closed when --cwd is empty, whitespace-only, or missing", async () => {
+    const homeDir = await tempDir("cam-hooks-empty-cwd-home-");
+    const projectDir = await tempDir("cam-hooks-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const cwd of ["", "   ", missingDir]) {
+      const result = runCli(projectDir, ["hooks", "install", "--cwd", cwd], {
+        env: { HOME: homeDir }
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
+  shellOnlyIt("supports --cwd while keeping generated hook helpers reusable across projects", async () => {
     const homeDir = await tempDir("cam-hooks-cwd-home-");
     const projectParentDir = await tempDir("cam-hooks-cwd-parent-");
     const projectDir = path.join(projectParentDir, "project with spaces");

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  initGitRepo,
+  writeCamConfig
+} from "./helpers/cam-test-fixtures.js";
+import { runCli } from "./helpers/cli-runner.js";
+
+const tempDirs: string[] = [];
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+}
+
+const expectedProjectInitConfig = {
+  autoMemoryEnabled: true,
+  extractorMode: "codex",
+  defaultScope: "project",
+  maxStartupLines: 200,
+  sessionContinuityAutoLoad: false,
+  sessionContinuityAutoSave: false,
+  sessionContinuityLocalPathStyle: "codex",
+  maxSessionContinuityLines: 60,
+  codexBinary: "codex"
+};
+
+const expectedLocalInitConfig = {
+  autoMemoryEnabled: true
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("cam init", () => {
+  it("keeps existing valid init config files by default", async () => {
+    const homeDir = await tempDir("cam-init-home-");
+    const repoDir = await tempDir("cam-init-repo-");
+    const customMemoryRoot = await tempDir("cam-init-custom-memory-");
+    await initGitRepo(repoDir);
+
+    const existingProjectConfig = {
+      ...expectedProjectInitConfig,
+      defaultScope: "project-local",
+      sessionContinuityAutoLoad: true,
+      codexBinary: "codex-dev"
+    };
+    const existingLocalConfig = {
+      autoMemoryEnabled: false,
+      autoMemoryDirectory: customMemoryRoot,
+      sessionContinuityAutoSave: true
+    };
+    await writeCamConfig(repoDir, existingProjectConfig, existingLocalConfig);
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(existingProjectConfig);
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(existingLocalConfig);
+    expect(await pathExists(customMemoryRoot)).toBe(true);
+    expect(await fs.readFile(path.join(repoDir, ".gitignore"), "utf8")).toContain(
+      ".codex-auto-memory.local.json"
+    );
+    expect(await fs.readFile(path.join(repoDir, ".git", "info", "exclude"), "utf8")).toContain(
+      ".codex-auto-memory/"
+    );
+  });
+
+  it("overwrites existing init config files when --force is passed", async () => {
+    const homeDir = await tempDir("cam-init-force-home-");
+    const repoDir = await tempDir("cam-init-force-repo-");
+    const customMemoryRoot = await tempDir("cam-init-force-custom-memory-");
+    await initGitRepo(repoDir);
+
+    await writeCamConfig(
+      repoDir,
+      {
+        ...expectedProjectInitConfig,
+        defaultScope: "project-local",
+        codexBinary: "codex-dev"
+      },
+      {
+        autoMemoryEnabled: false,
+        autoMemoryDirectory: customMemoryRoot
+      }
+    );
+
+    const result = runCli(repoDir, ["init", "--force"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
+      expectedLocalInitConfig
+    );
+  });
+
+  it("fails closed on invalid existing init config without --force", async () => {
+    const homeDir = await tempDir("cam-init-invalid-home-");
+    const repoDir = await tempDir("cam-init-invalid-repo-");
+    const memoryRootParent = await tempDir("cam-init-invalid-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "codex-auto-memory.json"), "{\n", "utf8");
+    await fs.writeFile(
+      path.join(repoDir, ".codex-auto-memory.local.json"),
+      JSON.stringify({ autoMemoryDirectory: memoryRoot }, null, 2),
+      "utf8"
+    );
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Re-run with --force");
+    expect(await fs.readFile(path.join(repoDir, "codex-auto-memory.json"), "utf8")).toBe("{\n");
+    expect(await pathExists(memoryRoot)).toBe(false);
+  });
+
+  it("rebuilds invalid existing init config when --force is passed", async () => {
+    const homeDir = await tempDir("cam-init-rebuild-home-");
+    const repoDir = await tempDir("cam-init-rebuild-repo-");
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "codex-auto-memory.json"), "{\n", "utf8");
+    await fs.writeFile(path.join(repoDir, ".codex-auto-memory.local.json"), "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init", "--force"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+    expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
+      expectedLocalInitConfig
+    );
+  });
+});

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -9,6 +9,8 @@ import {
 import { runCli } from "./helpers/cli-runner.js";
 
 const tempDirs: string[] = [];
+const originalHome = process.env.HOME;
+const originalManagedConfig = process.env.CAM_MANAGED_CONFIG;
 
 async function tempDir(prefix: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", prefix));
@@ -46,6 +48,12 @@ const expectedLocalInitConfig = {
 };
 
 afterEach(async () => {
+  process.env.HOME = originalHome;
+  if (originalManagedConfig === undefined) {
+    delete process.env.CAM_MANAGED_CONFIG;
+  } else {
+    process.env.CAM_MANAGED_CONFIG = originalManagedConfig;
+  }
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -166,6 +174,7 @@ describe("cam init", () => {
     const homeDir = await tempDir("cam-init-invalid-user-home-");
     const repoDir = await tempDir("cam-init-invalid-user-repo-");
     await initGitRepo(repoDir);
+    process.env.HOME = homeDir;
 
     const userConfigPath = configPaths.getUserConfigPath();
     await fs.mkdir(path.dirname(userConfigPath), { recursive: true });
@@ -189,6 +198,7 @@ describe("cam init", () => {
       "config.json"
     );
     await initGitRepo(repoDir);
+    process.env.HOME = homeDir;
 
     await fs.writeFile(managedConfigPath, "{\n", "utf8");
 

--- a/test/init-command.test.ts
+++ b/test/init-command.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { configPaths } from "../src/lib/config/load-config.js";
 import {
   initGitRepo,
   writeCamConfig
@@ -158,6 +159,49 @@ describe("cam init", () => {
     );
     expect(await readJson(path.join(repoDir, ".codex-auto-memory.local.json"))).toEqual(
       expectedLocalInitConfig
+    );
+  });
+
+  it("does not let an invalid user config outside the target project block init", async () => {
+    const homeDir = await tempDir("cam-init-invalid-user-home-");
+    const repoDir = await tempDir("cam-init-invalid-user-repo-");
+    await initGitRepo(repoDir);
+
+    const userConfigPath = configPaths.getUserConfigPath();
+    await fs.mkdir(path.dirname(userConfigPath), { recursive: true });
+    await fs.writeFile(userConfigPath, "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
+    );
+  });
+
+  it("does not let an invalid managed config block init", async () => {
+    const homeDir = await tempDir("cam-init-invalid-managed-home-");
+    const repoDir = await tempDir("cam-init-invalid-managed-repo-");
+    const managedConfigPath = path.join(
+      await tempDir("cam-init-invalid-managed-config-"),
+      "config.json"
+    );
+    await initGitRepo(repoDir);
+
+    await fs.writeFile(managedConfigPath, "{\n", "utf8");
+
+    const result = runCli(repoDir, ["init"], {
+      env: {
+        HOME: homeDir,
+        CAM_MANAGED_CONFIG: managedConfigPath
+      }
+    });
+
+    expect(result.exitCode, result.stderr).toBe(0);
+    expect(await readJson(path.join(repoDir, "codex-auto-memory.json"))).toEqual(
+      expectedProjectInitConfig
     );
   });
 });

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -125,6 +125,25 @@ afterEach(async () => {
 });
 
 describe("integrations command", () => {
+  it("fails closed when integrations install and doctor use empty, whitespace-only, or missing --cwd", async () => {
+    const homeDir = await tempDir("cam-integrations-empty-cwd-home-");
+    const projectDir = await tempDir("cam-integrations-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const command of [
+      ["integrations", "install", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", missingDir]) {
+        const result = runCli(projectDir, [...command, "--cwd", cwd], {
+          env: buildStableCliEnv(homeDir)
+        });
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+      }
+    }
+  });
   it("installs the recommended Codex integration stack without creating memory layout", async () => {
     const homeDir = await tempDir("cam-integrations-home-");
     const projectDir = await tempDir("cam-integrations-project-");

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -125,7 +125,7 @@ afterEach(async () => {
 });
 
 describe("integrations command", () => {
-  it("fails closed when integrations install and doctor use empty, whitespace-only, or missing --cwd", async () => {
+  it("fails closed when integrations install, apply, and doctor use empty, whitespace-only, or missing --cwd", async () => {
     const homeDir = await tempDir("cam-integrations-empty-cwd-home-");
     const projectDir = await tempDir("cam-integrations-empty-cwd-project-");
     process.env.HOME = homeDir;
@@ -133,6 +133,7 @@ describe("integrations command", () => {
 
     for (const command of [
       ["integrations", "install", "--host", "codex"] as const,
+      ["integrations", "apply", "--host", "codex"] as const,
       ["integrations", "doctor", "--host", "codex"] as const
     ]) {
       for (const cwd of ["", "   ", missingDir]) {

--- a/test/session-command.test.ts
+++ b/test/session-command.test.ts
@@ -57,6 +57,15 @@ process.exit(0);
   return mockCodexPath;
 }
 
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("runSession", () => {
   it("shows an empty compact prior preview when no continuity audit history exists", async () => {
     const repoDir = await tempDir("cam-session-empty-history-repo-");
@@ -574,6 +583,65 @@ describe("runSession", () => {
     expect(statusPayload.startup.continuitySectionKinds).toContain("sources");
     expect(statusPayload.projectLocation.exists).toBe(true);
     expect(statusPayload.localLocation.exists).toBe(false);
+  }, 30_000);
+
+  it("keeps session load and status read-only on an uninitialized project", async () => {
+    const homeDir = await tempDir("cam-session-readonly-home-");
+    const projectDir = await tempDir("cam-session-readonly-project-");
+    const memoryRootParent = await tempDir("cam-session-readonly-memory-parent-");
+    const memoryRoot = path.join(memoryRootParent, "memory-root");
+    await initRepo(projectDir);
+
+    await writeProjectConfig(
+      projectDir,
+      configJson(),
+      { autoMemoryDirectory: memoryRoot }
+    );
+
+    const statusResult = runCli(projectDir, ["session", "status", "--json"], {
+      env: { HOME: homeDir }
+    });
+    const loadResult = runCli(projectDir, ["session", "load", "--json", "--print-startup"], {
+      env: { HOME: homeDir }
+    });
+
+    expect(statusResult.exitCode, statusResult.stderr).toBe(0);
+    expect(loadResult.exitCode, loadResult.stderr).toBe(0);
+    expect(JSON.parse(statusResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(JSON.parse(loadResult.stdout)).toMatchObject({
+      projectLocation: {
+        exists: false
+      },
+      localLocation: {
+        exists: false
+      },
+      latestContinuityAuditEntry: null,
+      latestContinuityDiagnostics: null,
+      pendingContinuityRecovery: null,
+      startup: {
+        sourceFiles: [],
+        candidateSourceFiles: [],
+        continuityMode: "startup",
+        continuityProvenanceKind: "temporary-continuity"
+      }
+    });
+    expect(await pathExists(memoryRoot)).toBe(false);
   }, 30_000);
 
   it("refresh replaces only the selected scope", async () => {

--- a/test/skills-command.test.ts
+++ b/test/skills-command.test.ts
@@ -31,6 +31,21 @@ afterEach(async () => {
 });
 
 describe("skills command", () => {
+  it("fails closed when --cwd is empty, whitespace-only, or missing", async () => {
+    const homeDir = await tempDir("cam-skills-empty-cwd-home-");
+    const projectDir = await tempDir("cam-skills-empty-cwd-project-");
+    process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
+    const missingDir = path.join(projectDir, "missing-project");
+
+    for (const cwd of ["", "   ", missingDir]) {
+      const result = runCli(projectDir, ["skills", "install", "--cwd", cwd], {
+        env: { HOME: homeDir }
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    }
+  });
   it("installs a Codex skill for progressive durable memory retrieval", async () => {
     const homeDir = await tempDir("cam-skills-home-");
     const projectDir = await tempDir("cam-skills-project-");

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -924,17 +924,22 @@ describe("tarball install smoke", () => {
       }
     });
 
-    for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
-      const invalidDoctorResult = runCommandCapture(
-        camBinaryPath(installDir),
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        blockedProjectDir,
-        envWithBin
-      );
-      expect(invalidDoctorResult.exitCode).toBe(1);
-      expect(invalidDoctorResult.stderr).toContain(
-        "--cwd must be a non-empty path to an existing directory."
-      );
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
+        const invalidResult = runCommandCapture(
+          camBinaryPath(installDir),
+          [...command, "--cwd", cwd],
+          blockedProjectDir,
+          envWithBin
+        );
+        expect(invalidResult.exitCode).toBe(1);
+        expect(invalidResult.stderr).toContain(
+          "--cwd must be a non-empty path to an existing directory."
+        );
+      }
     }
 
     const recallHelpResult = runCommandCapture(

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -924,6 +924,19 @@ describe("tarball install smoke", () => {
       }
     });
 
+    for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
+      const invalidDoctorResult = runCommandCapture(
+        camBinaryPath(installDir),
+        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
+        blockedProjectDir,
+        envWithBin
+      );
+      expect(invalidDoctorResult.exitCode).toBe(1);
+      expect(invalidDoctorResult.stderr).toContain(
+        "--cwd must be a non-empty path to an existing directory."
+      );
+    }
+
     const recallHelpResult = runCommandCapture(
       camBinaryPath(installDir),
       ["recall", "search", "--help"],

--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -6,6 +6,7 @@ describe("vitest config", () => {
   it("excludes project-local worktree directories from test discovery", async () => {
     const configSource = await fs.readFile(path.resolve("vitest.config.ts"), "utf8");
 
+    expect(configSource).toContain("configDefaults.exclude");
     expect(configSource).toContain("**/.worktrees/**");
     expect(configSource).toContain("**/worktrees/**");
   });

--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("vitest config", () => {
+  it("excludes project-local worktree directories from test discovery", async () => {
+    const configSource = await fs.readFile(path.resolve("vitest.config.ts"), "utf8");
+
+    expect(configSource).toContain("**/.worktrees/**");
+    expect(configSource).toContain("**/worktrees/**");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    exclude: ["**/.worktrees/**", "**/worktrees/**"],
     fileParallelism: false,
     hookTimeout: 30_000,
     testTimeout: 30_000

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: ["**/.worktrees/**", "**/worktrees/**"],
+    exclude: [...configDefaults.exclude, "**/.worktrees/**", "**/worktrees/**"],
     fileParallelism: false,
     hookTimeout: 30_000,
     testTimeout: 30_000


### PR DESCRIPTION
## Summary

- follows #20 with a narrow session-inspection closure for issue5 closeout
- makes `cam session status` and `cam session load` truly read-only by avoiding implicit durable-memory layout creation during inspection
- adds source and compiled regression coverage so uninitialized projects keep returning continuity inspection payloads without writing `MEMORY.md`, `ARCHIVE.md`, or retrieval sidecars

## Included

- session command bootstrap split so `save`/`refresh`/`clear`/`open` keep the writable runtime path while `status`/`load` use a read-only runtime bootstrap
- new CLI regression in `test/session-command.test.ts` for uninitialized-project `status/load` behavior
- new compiled smoke coverage in `test/dist-cli-smoke.test.ts` for the same read-only session inspection contract

## Excluded

- no `cam init` idempotency or `--force` redesign yet
- no Vitest `.worktrees/**` isolation changes yet
- no tarball MCP smoke or docs/help parity sweep yet

## Verification

- `pnpm exec vitest run test/session-command.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm exec vitest run test/dist-cli-smoke.test.ts -t "keeps session inspection read-only"`

## Stack Notes

- branch: `pr/issue5-15-session-readonly-closure`
- base: `pr/issue5-14-runtime-safety-closure`
- head commit: `046a1a7`
- backup refs created before implementation:
  - `backup/2026-04-10-pr15-start-pr14-20260410-234202`
  - `backup-tag/2026-04-10-pr15-start-pr14-20260410-234202`

## Review Order

- Active issue5 follow-up stack position: 8 of 10
- Review this after #20 and before the next two follow-ups in this wave.

## Summary by Sourcery

Ensure session inspection commands operate in a read-only mode and add regression coverage for compiled and source CLIs.

Bug Fixes:
- Prevent `cam session status` and `cam session load` from implicitly creating durable memory layouts during inspection, keeping uninitialized projects read-only.

Enhancements:
- Split session runtime initialization so write operations use a full writable runtime while read-only inspection uses a runtime that skips memory layout creation.

Tests:
- Add regression tests to verify `session status` and `session load` remain read-only for uninitialized projects in the source CLI.
- Add compiled CLI smoke test to ensure session inspection does not create memory layouts or related files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps session inspection read-only and tightens runtime safety across init, integrations, and extractor. Adds an explicit, idempotent `init` with `--force`, and hardens `--cwd` handling.

- **Bug Fixes**
  - Route `session status`/`load` through a read-only runtime (`ensureMemoryLayout: false`); add source and compiled CLI tests to confirm no memory layout creation and temporary continuity.
  - Make `cam init` explicit and idempotent: `--force` overwrites; by default keep valid project/local configs, ignore invalid global/managed configs, and don’t create memory layout during init.
  - Fail closed on invalid `--cwd` for `integrations`/`hooks`/`skills` (empty/whitespace/missing); `mcp doctor` resolves and validates `--cwd`; add dist and tarball smoke coverage.
  - Preserve issue-tracker memories by using host- and repo-aware keys; prevent collapsing cross-host or same-host tickets with different IDs.

<sup>Written for commit 076eccb2b1c410ef3d27bab1b3c53bcb711c32c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

