### PR TITLE
fix: close issue5 tail closeout blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,11 @@ cam session status
 当前优先事项：
 
 1. 继续保持 issue5 stack 的 reviewer contract、help surface、release-facing smoke 一致
-2. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
-3. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
-4. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
-5. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
+2. 收紧 issue-tracker durable memory replacement key，避免不同 host 的 tracker URL 因相同 repo/path 或 ticket id 被误判为同一条 memory
+3. 把 Claude Code / Gemini CLI 的官方公开宿主能力面，与本仓当前真实支持的 manual-only host 边界继续写清楚
+4. 保持 `Markdown-first` canonical store 与 sidecar retrieval plane 的边界稳定
+5. 保持 `cam integrations install` 与 `cam integrations apply` 的 AGENTS mutation boundary 清晰
+6. 继续扩大 deterministic release gate：`lint`、`test`、`docs-contract`、`dist-cli-smoke`、`tarball-install-smoke`
 
 下一阶段建议：
 
@@ -106,6 +107,7 @@ cam session status
 
 ## 变更记录
 
+- 2026-04-11: issue5 tail closeout 新增 cross-host issue-tracker 回归保护：`directive-utils` 现在用完整的 non-generic hostname 片段构造 issue-tracker resource key，避免不同 host 但相同 repo/path 或 ticket id 的 URL 互相覆盖；同时补强 `vitest.config.ts` 的默认 exclude contract 测试，并把 `integrations apply --cwd` 的 invalid-path fail-closed 行为纳入 source / dist / tarball 回归覆盖。
 - 2026-04-10: issue5 PR14 收口了三类 runtime contract seam：`mcp` 命令的空 `--cwd` 现在 fail-closed；`workflowContract` 的 resolved launcher 与显式 `launcherOverride` 保持一致；delete-only 的 forget follow-up 文案不再硬编码裸 `cam recall timeline`。
 - 2026-04-10: `test/recovery-records.test.ts` 已对齐当前 continuity 语义：`scope=both` continuity recovery marker 可以被后续 single-scope save/refresh 复用，并继续由 `session-command` 行为测试锁定。
 - 2026-04-10: 新增根级 `AGENTS.md`，补齐仓库级功能说明、命令面、关键 JSON 契约与项目规划。

--- a/src/lib/extractor/directive-utils.ts
+++ b/src/lib/extractor/directive-utils.ts
@@ -51,7 +51,8 @@ function resourceTokenFromUrl(url: string, category: string): string | null {
         .map((segment) => slugify(segment))
         .filter(Boolean);
       const hostContextToken =
-        hostTokens.find((token) => !genericHostTokens.has(token)) ?? slugify(parsed.hostname);
+        hostTokens.filter((token) => !genericHostTokens.has(token)).join("-") ||
+        slugify(parsed.hostname);
       const contextToken = nonGenericPathTokens.slice(-2).join("-") || ticketToken;
 
       return [hostContextToken, contextToken].filter(Boolean).join("-") || category;

--- a/test/dist-cli-smoke.test.ts
+++ b/test/dist-cli-smoke.test.ts
@@ -1694,21 +1694,26 @@ describe("dist cli smoke", () => {
     });
   });
 
-  it("fails closed for invalid --cwd on the compiled integrations doctor entrypoint", async () => {
+  it("fails closed for invalid --cwd on compiled integrations entrypoints", async () => {
     const homeDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-home-");
     const projectDir = await tempDir("cam-dist-integrations-doctor-invalid-cwd-project-");
 
-    for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
-      const result = runCli(
-        projectDir,
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        {
-          entrypoint: "dist",
-          env: { HOME: homeDir }
-        }
-      );
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(projectDir, "missing-project")]) {
+        const result = runCli(
+          projectDir,
+          [...command, "--cwd", cwd],
+          {
+            entrypoint: "dist",
+            env: { HOME: homeDir }
+          }
+        );
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain("--cwd must be a non-empty path to an existing directory.");
+      }
     }
   });
 

--- a/test/extractor.test.ts
+++ b/test/extractor.test.ts
@@ -1366,6 +1366,93 @@ describe("HeuristicExtractor", () => {
     );
   });
 
+  it("does not collapse cross-host issue tracker URLs that share the same repo path and ticket id", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "github-foo-widgets-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://github.foo.example.com/acme/widgets/issues/123",
+        details: ["Primary GitHub Enterprise tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: [
+          "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123."
+        ]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "github-foo-widgets-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary:
+            "Issues are tracked at https://github.bar.example.com/acme/widgets/issues/123"
+        })
+      ])
+    );
+  });
+
+  it("does not collapse cross-host issue tracker URLs that share the same ticket id behind a generic browse path", async () => {
+    const extractor = new HeuristicExtractor();
+    const existingEntries: MemoryEntry[] = [
+      {
+        id: "jira-foo-auth-123",
+        scope: "project",
+        topic: "reference",
+        summary: "Issues are tracked at https://jira.foo.example.com/browse/AUTH-123",
+        details: ["Primary Jira issue tracker pointer."],
+        updatedAt: "2026-03-14T00:00:00.000Z",
+        sources: ["old"]
+      }
+    ];
+
+    const operations = await extractor.extract(
+      baseEvidence({
+        userMessages: ["Issues are tracked at https://jira.bar.example.com/browse/AUTH-123."]
+      }),
+      existingEntries
+    );
+    const reviewed = reviewExtractedMemoryOperations(operations, existingEntries);
+
+    expect(reviewed.operations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "delete",
+          topic: "reference",
+          id: "jira-foo-auth-123"
+        })
+      ])
+    );
+    expect(reviewed.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "upsert",
+          topic: "reference",
+          summary: "Issues are tracked at https://jira.bar.example.com/browse/AUTH-123"
+        })
+      ])
+    );
+  });
+
   it("does not suppress different issue tracker URLs when both use a generic browse tail", () => {
     const reviewed = reviewExtractedMemoryOperations(
       [

--- a/test/integrations-command.test.ts
+++ b/test/integrations-command.test.ts
@@ -125,7 +125,7 @@ afterEach(async () => {
 });
 
 describe("integrations command", () => {
-  it("fails closed when integrations install and doctor use empty, whitespace-only, or missing --cwd", async () => {
+  it("fails closed when integrations install, apply, and doctor use empty, whitespace-only, or missing --cwd", async () => {
     const homeDir = await tempDir("cam-integrations-empty-cwd-home-");
     const projectDir = await tempDir("cam-integrations-empty-cwd-project-");
     process.env.HOME = homeDir;
@@ -133,6 +133,7 @@ describe("integrations command", () => {
 
     for (const command of [
       ["integrations", "install", "--host", "codex"] as const,
+      ["integrations", "apply", "--host", "codex"] as const,
       ["integrations", "doctor", "--host", "codex"] as const
     ]) {
       for (const cwd of ["", "   ", missingDir]) {

--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -924,17 +924,22 @@ describe("tarball install smoke", () => {
       }
     });
 
-    for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
-      const invalidDoctorResult = runCommandCapture(
-        camBinaryPath(installDir),
-        ["integrations", "doctor", "--host", "codex", "--cwd", cwd],
-        blockedProjectDir,
-        envWithBin
-      );
-      expect(invalidDoctorResult.exitCode).toBe(1);
-      expect(invalidDoctorResult.stderr).toContain(
-        "--cwd must be a non-empty path to an existing directory."
-      );
+    for (const command of [
+      ["integrations", "apply", "--host", "codex"] as const,
+      ["integrations", "doctor", "--host", "codex"] as const
+    ]) {
+      for (const cwd of ["", "   ", path.join(realBlockedProjectDir, "missing-project")]) {
+        const invalidResult = runCommandCapture(
+          camBinaryPath(installDir),
+          [...command, "--cwd", cwd],
+          blockedProjectDir,
+          envWithBin
+        );
+        expect(invalidResult.exitCode).toBe(1);
+        expect(invalidResult.stderr).toContain(
+          "--cwd must be a non-empty path to an existing directory."
+        );
+      }
     }
 
     const recallHelpResult = runCommandCapture(

--- a/test/vitest-config.test.ts
+++ b/test/vitest-config.test.ts
@@ -6,6 +6,7 @@ describe("vitest config", () => {
   it("excludes project-local worktree directories from test discovery", async () => {
     const configSource = await fs.readFile(path.resolve("vitest.config.ts"), "utf8");
 
+    expect(configSource).toContain("configDefaults.exclude");
     expect(configSource).toContain("**/.worktrees/**");
     expect(configSource).toContain("**/worktrees/**");
   });


### PR DESCRIPTION
## Summary

- follows #25 with a narrow closeout unblock for the last audited issue5 tail blockers
- prevents cross-host issue-tracker URLs from collapsing into one durable memory replacement key when repo/path or ticket ids match
- strengthens the Vitest config regression so the worktree exclude contract still requires `configDefaults.exclude`
- extends invalid `--cwd` fail-closed coverage to `integrations apply` across source, compiled, and tarball smoke surfaces

## Included

- full non-generic hostname context in issue-tracker resource keys
- new extractor regressions for cross-host GitHub Enterprise and Jira tracker URLs
- stronger `vitest.config.ts` contract assertion that also locks `configDefaults.exclude`
- source / dist / tarball regression coverage for `integrations apply --cwd` invalid path handling
- additive root `AGENTS.md` changelog and planning note for this closeout wave

## Excluded

- no new product-surface behavior beyond the audited blocker fixes above
- no restack / retarget rewrite for the wider issue5 stack
- no malformed user config fail-soft redesign in runtime load paths

## Verification

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:dist-cli-smoke`
- `pnpm test:tarball-install-smoke`

## Stack Notes

- branch: `fix/issue5-tail-closeout-unblock-2026-04-11`
- base: `pr/issue5-19-shared-cwd-fail-closed`
- head commit: `805f319`
- backup refs created before implementation:
  - `backup/2026-04-11-pre-tail-closeout-unblock-20260411-233050`
  - matching `backup-tag/...`

## Review Order

- review this after #25
- this PR only absorbs the audited tail blocker fixes; it does not change the wider base-chain reality above #17/#18

## Summary by Sourcery

Tighten issue-tracker URL keying and extend CLI fail-closed and config regression coverage for the remaining issue5 tail blockers.

Bug Fixes:
- Preserve distinct durable memory entries for issue-tracker URLs from different hosts even when repo/path and ticket IDs match.

Enhancements:
- Refine issue-tracker resource key generation to use full non-generic hostname context, reducing cross-host collisions.
- Strengthen Vitest configuration contract by asserting that worktree exclusions are wired through via `configDefaults.exclude`.

Documentation:
- Update `AGENTS.md` changelog and priorities to document the issue5 tail closeout protections and testing contracts.

Tests:
- Add extractor regressions for cross-host GitHub Enterprise and Jira issue-tracker URLs to guard against memory key collisions.
- Expand invalid `--cwd` fail-closed tests to cover `integrations apply` across source, compiled dist CLI, and tarball installation surfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-host issue-tracker URLs from collapsing into the same memory key and extends fail-closed handling for invalid `--cwd` to `integrations apply` across all entrypoints. Tightens the `vitest` config contract to keep worktree dirs excluded.

- **Bug Fixes**
  - Issue tracker keys now include full non-generic hostname to avoid collisions across hosts; adds regressions for GitHub Enterprise and Jira cross-host URLs.
  - `integrations apply` and `doctor` now fail closed on empty/whitespace/missing `--cwd` in source, compiled dist, and tarball CLIs.
  - Asserts `configDefaults.exclude` in `vitest.config.ts` so worktree directories stay out of test discovery.

<sup>Written for commit 805f319a97725be01aee5676def733abd6bf452b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

