### PR TITLE
chore: ignore project-local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 coverage/
 .tmp/
+.worktrees/
 
 # Sensitive files
 .env


### PR DESCRIPTION
## Summary
- ignore the repository-local \.worktrees/ container
- reduce untracked noise from local git worktree checkouts
- keep this cleanup separate from the old divergent local main history

## Verification
- git diff --check
- git check-ignore -v .worktrees
- reviewer audit: no blocking findings

## Summary by Sourcery

Chores:
- Update .gitignore to exclude repository-local .worktrees/ directories from tracking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore repository-local `.worktrees/` directories in `.gitignore` to reduce untracked noise from Git worktree checkouts. This keeps local worktrees out of version control and avoids accidental commits.

<sup>Written for commit 8a7b4d07141cb33185aa4c029d713f3bd614d0ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to improve local development environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->