### PR TITLE
chore: split safe production dependency updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ cam session status
 
 ## 变更记录
 
+- 2026-04-18: 开始拆分吸收 dependabot `#34` 的低风险部分。当前分支先把 `@modelcontextprotocol/sdk` 升到 `1.29.0`、`smol-toml` 升到 `1.6.1`，保留 `zod v4` 迁移单独处理；本地已验证 `pnpm lint`、`pnpm test:dist-cli-smoke:only`、`pnpm test:tarball-install-smoke` 通过。
 - 2026-04-18: `PR #36` 已合并进 `main`，主线 Windows smoke 恢复为绿色；同时把 `.release-artifacts/` 加入 `.gitignore`，避免本地 `pack:release` / smoke 验证持续把工作树弄脏。`release.yml` 现在新增“同一 `GITHUB_SHA` 必须先有成功的 `CI` push run 才允许继续发版”的前置检查，并补上 `actions: read` 权限，避免再出现主线 `CI` 仍红但 tag release 已经发出的情况。
 - 2026-04-16: Windows integration asset 幂等判定继续收口。`installIntegrationAssets` 现在在 Windows 上跳过 executable bit 的重复检查，避免 `integrations install/apply` 因 hooks 的 `chmod` 语义差异持续返回 `updated`；同时补上 `test/integration-install-assets.test.ts`，锁住 Windows 与 POSIX 的 executable 判定差异。
 - 2026-04-16: 收口 Windows tarball install smoke 回归。`runCommand` / `runCommandCapture` 现在在 Windows 下对 `.cmd` / `.bat` 显式走 `cmd.exe /d /s /c` 并自行拼接带引号的命令串，不再依赖 `shell: true` 的隐式参数拼接；对应补上 `test/process-util.test.ts` 对带空格参数的命令行构造断言，用来覆盖安装后 `cam.cmd ... --cwd "<path with spaces>"` 的 release-facing 场景。

--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.1",
-    "smol-toml": "^1.4.1",
+    "smol-toml": "^1.6.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
     "@types/node": "^24.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
-        version: 1.27.1(zod@3.25.76)
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       commander:
         specifier: ^14.0.1
         version: 14.0.3
       smol-toml:
-        specifier: ^1.4.1
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -250,8 +250,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1010,8 +1010,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -1337,7 +1337,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0
@@ -2115,7 +2115,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- absorb the low-risk portion of dependabot `#34` by updating `@modelcontextprotocol/sdk` to `^1.29.0`
- update `smol-toml` to `^1.6.1` to pick up the published security fix without pulling `zod v4` into the same change
- keep `zod` on `3.25.76` so the schema/runtime migration can be handled in a separate PR

## Verification
- `pnpm lint`
- `pnpm test:dist-cli-smoke:only`
- `pnpm test:tarball-install-smoke`

## Follow-up
- close or supersede dependabot `#34` after reviewing this narrower PR
- handle `zod v4` as a dedicated migration PR

## Summary by Sourcery

Update production dependencies to pick up safe upstream fixes while deferring breaking schema changes.

Bug Fixes:
- Pull in the latest smol-toml patch series to incorporate its published security fix.

Enhancements:
- Bump @modelcontextprotocol/sdk to ^1.29.0 while keeping zod on the existing 3.x line to avoid mixing in the v4 migration.
- Adjust dependency ordering in package.json devDependencies without changing behavior.
- Document the dependency upgrade strategy and verification commands for this split Dependabot update in AGENTS.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split safe production dependency updates to land SDK and TOML security patch without pulling in `zod v4`. Keeps runtime stable; the `zod` migration will be handled in a separate PR.

- **Dependencies**
  - Updated `@modelcontextprotocol/sdk` to `^1.29.0`.
  - Updated `smol-toml` to `^1.6.1` (security fix).
  - Kept `zod` at `3.25.76` to defer v4 migration.

<sup>Written for commit a0a907933ef87449fd393e6d3171427cb93b8c4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production dependencies to latest compatible versions for improved stability and feature support.
  * Local testing verification completed successfully, including code quality checks, CLI smoke tests, and installation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->