### PR TITLE
ci: force legacy actions onto node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - main
   pull_request:
 
+env:
+  # Keep v4 pinned for lockfile compatibility, but force JavaScript actions onto
+  # the Node 24 runtime so GitHub's Node 20 action deprecation does not block CI.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout
@@ -48,7 +52,6 @@ jobs:
       matrix:
         node: [22, 24]
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout
@@ -81,8 +84,6 @@ jobs:
     name: Platform Smoke (${{ matrix.os }}, Node 22)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -124,7 +125,6 @@ jobs:
           - os: windows-latest
             node: 22
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout
@@ -47,6 +48,7 @@ jobs:
       matrix:
         node: [22, 24]
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout
@@ -79,6 +81,8 @@ jobs:
     name: Platform Smoke (${{ matrix.os }}, Node 22)
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +124,7 @@ jobs:
           - os: windows-latest
             node: 22
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+env:
+  # Keep v4 pinned for lockfile compatibility, but force JavaScript actions onto
+  # the Node 24 runtime so GitHub's Node 20 action deprecation does not block releases.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -19,7 +24,6 @@ jobs:
       id-token: write
     timeout-minutes: 60
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       id-token: write
     timeout-minutes: 60
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- force GitHub Actions JavaScript actions onto the Node 24 runtime while keeping 
- preserve the documented  block because it still breaks this repo's lockfile flow
- validate this change through the normal PR CI path before any merge

## Verification
- pending PR CI

## Summary by Sourcery

CI:
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable to CI and release workflows to standardize JavaScript actions on the Node 24 runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force JavaScript GitHub Actions to run on Node 24 in CI and release workflows to avoid Node 20 deprecation breakage. Define `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` at the workflow level (deduped); no app or matrix changes.

<sup>Written for commit c8ff29526cbaf73c3e921b3462635e5c4ec8cfa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

