### PR TITLE
test: fix windows tarball smoke timeout

### DIFF
--- a/test/tarball-install-smoke.test.ts
+++ b/test/tarball-install-smoke.test.ts
@@ -11,6 +11,7 @@ import { makeAppConfig, writeCamConfig } from "./helpers/cam-test-fixtures.js";
 import { createIsolatedCliEnv, minimalCommandPath } from "./helpers/cli-runner.js";
 
 const tempDirs: string[] = [];
+let packedTarballPathCache: string | null = null;
 
 async function tempDir(prefix: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
@@ -37,6 +38,23 @@ function resolvePackedTarballPath(packDir: string, packStdout: string): string {
   }
 
   return path.isAbsolute(tarballRef) ? tarballRef : path.join(packDir, tarballRef);
+}
+
+function packedTarballPath(env: NodeJS.ProcessEnv): string {
+  if (packedTarballPathCache) {
+    return packedTarballPathCache;
+  }
+
+  const packResult = runCommandCapture(
+    pnpmCommand(),
+    ["pack:release"],
+    process.cwd(),
+    env
+  );
+  expect(packResult.exitCode, packResult.stderr).toBe(0);
+
+  packedTarballPathCache = resolvePackedTarballPath(path.resolve(".release-artifacts"), packResult.stdout);
+  return packedTarballPathCache;
 }
 
 function camBinaryPath(installDir: string): string {
@@ -81,6 +99,13 @@ function resolvePublicPathForTest(
 
 function isolatedEnv(homeDir: string): NodeJS.ProcessEnv {
   return createIsolatedCliEnv(homeDir);
+}
+
+function isolatedTarballInstallEnv(homeDir: string): NodeJS.ProcessEnv {
+  return {
+    ...isolatedEnv(homeDir),
+    npm_config_cache: path.resolve(".tmp", "npm-cache")
+  };
 }
 
 function expectWorkflowContractCore(
@@ -175,20 +200,12 @@ describe("tarball install smoke", () => {
     const homeDir = await tempDir("cam-tarball-home-");
     const installDir = await tempDir("cam-tarball-install-");
     const realInstallDir = await fs.realpath(installDir);
-    const env = isolatedEnv(homeDir);
+    const env = isolatedTarballInstallEnv(homeDir);
     const packageJson = JSON.parse(await fs.readFile(path.resolve("package.json"), "utf8")) as {
       version: string;
     };
 
-    const packResult = runCommandCapture(
-      pnpmCommand(),
-      ["pack:release"],
-      process.cwd(),
-      env
-    );
-    expect(packResult.exitCode, packResult.stderr).toBe(0);
-
-    const tarballPath = resolvePackedTarballPath(path.resolve(".release-artifacts"), packResult.stdout);
+    const tarballPath = packedTarballPath(env);
 
     const initResult = runCommandCapture(npmCommand(), ["init", "-y"], installDir, env);
     expect(initResult.exitCode).toBe(0);
@@ -2152,17 +2169,9 @@ describe("tarball install smoke", () => {
     const homeDir = await tempDir("cam-tarball-preserve-home-");
     const installDir = await tempDir("cam-tarball-preserve-install-");
     const realInstallDir = await fs.realpath(installDir);
-    const env = isolatedEnv(homeDir);
+    const env = isolatedTarballInstallEnv(homeDir);
 
-    const packResult = runCommandCapture(
-      pnpmCommand(),
-      ["pack:release"],
-      process.cwd(),
-      env
-    );
-    expect(packResult.exitCode, packResult.stderr).toBe(0);
-
-    const tarballPath = resolvePackedTarballPath(path.resolve(".release-artifacts"), packResult.stdout);
+    const tarballPath = packedTarballPath(env);
 
     expect(runCommandCapture(npmCommand(), ["init", "-y"], installDir, env).exitCode).toBe(0);
     expect(


### PR DESCRIPTION
## Summary\n- reuse a stable repo-local npm cache in tarball install smoke tests\n- reduce repeated cold-install cost that pushed the Windows install smoke job over the test timeout\n\n## Root cause\n- main CI run 24610883776 failed in \n- the failing test was \n- the failure was a timeout, not an assertion mismatch\n\n## Verification\n- pnpm test:tarball-install-smoke

## Summary by Sourcery

Reduce flakiness and timeouts in tarball install smoke tests by reusing a cached release tarball and a stable npm cache across test cases.

Bug Fixes:
- Prevent tarball install smoke tests from timing out on Windows by avoiding repeated cold installs for each test run.

Tests:
- Introduce shared tarball packing helper and a dedicated npm cache configuration to speed up tarball install smoke test execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows tarball install smoke test timeouts by caching dependencies and packing the tarball once per run. This reduces cold-install time and stabilizes CI on Windows.

- **Bug Fixes**
  - Set `npm_config_cache` to `.tmp/npm-cache` via `isolatedTarballInstallEnv` to reuse a repo-local `npm` cache.
  - Cache the packed tarball path and reuse it across tests instead of running `pnpm pack:release` for each test.

<sup>Written for commit 85e56c65eb1fc0f606d9b38bc975d802b88b0d74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized tarball installation test suite with improved caching and deterministic environment isolation to streamline test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->